### PR TITLE
Improve `ScaleObj` 

### DIFF
--- a/async_substrate_interface/substrate_interface.py
+++ b/async_substrate_interface/substrate_interface.py
@@ -151,6 +151,12 @@ class ScaleObj:
     def __len__(self):
         return len(self.value)
 
+    def serialize(self):
+        return self.value
+
+    def decode(self):
+        return self.value
+
     @classmethod
     def dumper(cls, obj):
         if isinstance(obj, ScaleObj):

--- a/async_substrate_interface/substrate_interface.py
+++ b/async_substrate_interface/substrate_interface.py
@@ -1087,10 +1087,7 @@ class AsyncSubstrateInterface:
         )
         if pre_initialize:
             if not _mock:
-                execute_coroutine(
-                    coroutine=self.initialize(),
-                    event_loop=self.event_loop,
-                )
+                self.event_loop.create_task(self.initialize())
             else:
                 self.reload_type_registry()
 

--- a/tests/unit_tests/test_substrate_interface.py
+++ b/tests/unit_tests/test_substrate_interface.py
@@ -8,13 +8,12 @@ from async_substrate_interface.substrate_interface import (
 )
 
 
-
-@pytest.mark.skip(reason="Issues with nested asyncio")
 @pytest.mark.asyncio
 async def test_invalid_url_raises_exception():
     """Test that invalid URI raises an InvalidURI exception."""
     with pytest.raises(InvalidURI):
-        AsyncSubstrateInterface("non_existent_entry_point")
+        async with AsyncSubstrateInterface("non_existent_entry_point"):
+            pass
 
 
 def test_scale_object():

--- a/tests/unit_tests/test_substrate_interface.py
+++ b/tests/unit_tests/test_substrate_interface.py
@@ -1,7 +1,10 @@
 import pytest
 from websockets.exceptions import InvalidURI
 
-from async_substrate_interface.substrate_interface import AsyncSubstrateInterface
+from async_substrate_interface.substrate_interface import (
+    AsyncSubstrateInterface,
+    ScaleObj,
+)
 
 
 @pytest.mark.asyncio
@@ -9,3 +12,55 @@ async def test_invalid_url_raises_exception():
     """Test that invalid URI raises an InvalidURI exception."""
     with pytest.raises(InvalidURI):
         AsyncSubstrateInterface("non_existent_entry_point")
+
+
+def test_scale_object():
+    """Verifies that the instance can be subject to various operations."""
+    # Preps
+    inst_int = ScaleObj(100)
+
+    # Asserts
+    assert inst_int + 1 == 101
+    assert 1 + inst_int == 101
+    assert inst_int - 1 == 99
+    assert 101 - inst_int == 1
+    assert inst_int * 2 == 200
+    assert 2 * inst_int == 200
+    assert inst_int / 2 == 50
+    assert 100 / inst_int == 1
+    assert inst_int // 2 == 50
+    assert 1001 // inst_int == 10
+    assert inst_int % 3 == 1
+    assert 1002 % inst_int == 2
+    assert inst_int >= 99
+    assert inst_int <= 101
+
+    # Preps
+    inst_str = ScaleObj("test")
+
+    # Asserts
+    assert inst_str + "test1" == "testtest1"
+    assert "test1" + inst_str == "test1test"
+    assert inst_str * 2 == "testtest"
+    assert 2 * inst_str == "testtest"
+    assert inst_str >= "test"
+    assert inst_str <= "testtest"
+    assert inst_str[0] == "t"
+    assert [i for i in inst_str] == ["t", "e", "s", "t"]
+
+    # Preps
+    inst_list = ScaleObj([1, 2, 3])
+
+    # Asserts
+    assert inst_list[0] == 1
+    assert inst_list[-1] == 3
+    assert inst_list * 2 == inst_list + inst_list
+    assert [i for i in inst_list] == [1, 2, 3]
+    assert inst_list >= [1, 2]
+    assert inst_list <= [1, 2, 3, 4]
+    assert len(inst_list) == 3
+
+    inst_dict = ScaleObj({"a": 1, "b": 2})
+    assert inst_dict["a"] == 1
+    assert inst_dict["b"] == 2
+    assert [i for i in inst_dict] == ["a", "b"]

--- a/tests/unit_tests/test_substrate_interface.py
+++ b/tests/unit_tests/test_substrate_interface.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 from websockets.exceptions import InvalidURI
 
@@ -7,6 +8,8 @@ from async_substrate_interface.substrate_interface import (
 )
 
 
+
+@pytest.mark.skip(reason="Issues with nested asyncio")
 @pytest.mark.asyncio
 async def test_invalid_url_raises_exception():
     """Test that invalid URI raises an InvalidURI exception."""


### PR DESCRIPTION

- to use `json.dumps` see the next example

```python
import json
from async_substrate_interface.substrate_interface import ScaleObj

id_ = ScaleObj(5)
paylod = {'jsonrpc': '2.0', 'method': 'neuronInfo_getNeuron', 'params': [23, id_], 'id': 0}

print(json.dumps(paylod, default=ScaleObj.dumper))
```

NOTE: json.dumps raises the error without `default=ScaleObj.dumper` usage.