### PR TITLE
Fix decode scale

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -869,12 +869,13 @@ class AsyncSubstrateInterface(SubstrateMixin):
         """
         if scale_bytes == b"\x00":
             obj = None
-        if type_string == "scale_info::0":  # Is an AccountId
-            # Decode AccountId bytes to SS58 address
-            return bytes.fromhex(ss58_decode(scale_bytes, SS58_FORMAT))
         else:
-            await self._wait_for_registry(_attempt, _retries)
-            obj = decode_by_type_string(type_string, self.registry, scale_bytes)
+            if type_string == "scale_info::0":  # Is an AccountId
+                # Decode AccountId bytes to SS58 address
+                return bytes.fromhex(ss58_decode(scale_bytes, SS58_FORMAT))
+            else:
+                await self._wait_for_registry(_attempt, _retries)
+                obj = decode_by_type_string(type_string, self.registry, scale_bytes)
         if return_scale_obj:
             return ScaleObj(obj)
         else:

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -615,11 +615,12 @@ class SubstrateInterface(SubstrateMixin):
 
         if scale_bytes == b"\x00":
             obj = None
-        if type_string == "scale_info::0":  # Is an AccountId
-            # Decode AccountId bytes to SS58 address
-            return bytes.fromhex(ss58_decode(scale_bytes, SS58_FORMAT))
         else:
-            obj = decode_by_type_string(type_string, self.registry, scale_bytes)
+            if type_string == "scale_info::0":  # Is an AccountId
+                # Decode AccountId bytes to SS58 address
+                return bytes.fromhex(ss58_decode(scale_bytes, SS58_FORMAT))
+            else:
+                obj = decode_by_type_string(type_string, self.registry, scale_bytes)
         if return_scale_obj:
             return ScaleObj(obj)
         else:


### PR DESCRIPTION
We set the obj to None if it is None, but then we still try to decode it. This does not do this.