### PR TITLE
Improves the error-handling of initialisation of the object

### DIFF
--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -343,6 +343,7 @@ class SubstrateMixin(ABC):
     _token_decimals = None
     _token_symbol = None
     _metadata = None
+    metadata_v15 = None
     _chain: str
     runtime_config: RuntimeConfigurationObject
     type_registry: Optional[dict]


### PR DESCRIPTION
- `self.metadata_v15` moved to Mixin so it will never raise an attribute error
- raise an error during get_runtime if `self.metadata_v15` is `None`, indicating that the object was not correctly initialised.