### PR TITLE
Generate UIDs for websockets

### DIFF
--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -30,7 +30,7 @@ from async_substrate_interface.types import (
     Preprocessed,
     ScaleObj,
 )
-from async_substrate_interface.utils import hex_to_bytes, json
+from async_substrate_interface.utils import hex_to_bytes, json, generate_unique_id
 from async_substrate_interface.utils.decoding import (
     _determine_if_old_runtime_call,
     _bt_decode_to_dict_or_list,
@@ -1681,9 +1681,9 @@ class SubstrateInterface(SubstrateMixin):
         subscription_added = False
 
         ws = self.connect(init=False if attempt == 1 else True)
-        item_id = 0
         for payload in payloads:
-            item_id += 1
+            payload_str = json.dumps(payload["payload"])
+            item_id = generate_unique_id(payload_str)
             ws.send(json.dumps({**payload["payload"], **{"id": item_id}}))
             request_manager.add_request(item_id, payload["id"])
 

--- a/async_substrate_interface/utils/__init__.py
+++ b/async_substrate_interface/utils/__init__.py
@@ -1,4 +1,10 @@
 import importlib
+import hashlib
+
+
+def generate_unique_id(item: str, length=10):
+    hashed_value = hashlib.sha256(item.encode()).hexdigest()
+    return hashed_value[:length]
 
 
 def hex_to_bytes(hex_str: str) -> bytes:


### PR DESCRIPTION
Avoids the problem of cancelling a request and receiving the response of the next as your expected previous response.