### PR TITLE
Closes the connection on the object being garbage-collected

### DIFF
--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -525,6 +525,9 @@ class SubstrateInterface(SubstrateMixin):
         self.initialize()
         return self
 
+    def __del__(self):
+        self.close()
+
     def initialize(self):
         """
         Initialize the connection to the chain.


### PR DESCRIPTION
This handles the connection closing via garbage collection. When the SubstrateInterface object falls out of scope, it automatically closes the websocket connection.