### PR TITLE
Handle options with bt-decode

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -892,15 +892,12 @@ class AsyncSubstrateInterface(SubstrateMixin):
         Returns:
             Decoded object
         """
-        if scale_bytes == b"\x00":
-            obj = None
+        if type_string == "scale_info::0":  # Is an AccountId
+            # Decode AccountId bytes to SS58 address
+            return ss58_encode(scale_bytes, SS58_FORMAT)
         else:
-            if type_string == "scale_info::0":  # Is an AccountId
-                # Decode AccountId bytes to SS58 address
-                return ss58_encode(scale_bytes, SS58_FORMAT)
-            else:
-                await self._wait_for_registry(_attempt, _retries)
-                obj = decode_by_type_string(type_string, self.registry, scale_bytes)
+            await self._wait_for_registry(_attempt, _retries)
+            obj = decode_by_type_string(type_string, self.registry, scale_bytes)
         if return_scale_obj:
             return ScaleObj(obj)
         else:

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -652,15 +652,11 @@ class SubstrateInterface(SubstrateMixin):
         Returns:
             Decoded object
         """
-
-        if scale_bytes == b"\x00":
-            obj = None
+        if type_string == "scale_info::0":  # Is an AccountId
+            # Decode AccountId bytes to SS58 address
+            return ss58_encode(scale_bytes, SS58_FORMAT)
         else:
-            if type_string == "scale_info::0":  # Is an AccountId
-                # Decode AccountId bytes to SS58 address
-                return ss58_encode(scale_bytes, SS58_FORMAT)
-            else:
-                obj = decode_by_type_string(type_string, self.registry, scale_bytes)
+            obj = decode_by_type_string(type_string, self.registry, scale_bytes)
         if return_scale_obj:
             return ScaleObj(obj)
         else:


### PR DESCRIPTION
bt-decode handles options properly now, so we don't have to include the check for a none scale value.