### PR TITLE
Feat/mvds00/runtime version fixes

### DIFF
--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -773,10 +773,12 @@ class SubstrateInterface(SubstrateMixin):
                 )
 
         runtime = Runtime(
-                self.chain,
-                self.runtime_config,
-                metadata,
-                self.type_registry,
+                chain=self.chain,
+                runtime_config=self.runtime_config,
+                metadata=metadata,
+                type_registry=self.type_registry,
+                metadata_v15=metadata_v15,
+                runtime_info=runtime_info,
             )
         self.runtime_cache.add_item(runtime_version=runtime_version, runtime=runtime)
         return runtime

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -720,7 +720,7 @@ class SubstrateInterface(SubstrateMixin):
         if not block_hash:
             block_hash = self.get_chain_head()
 
-        runtime = self.runtime_cache.retrieve(block_id, block_hash)
+        runtime = self.runtime_cache.retrieve(block_hash=block_hash)
         if runtime and runtime.metadata is not None:
             return runtime
 
@@ -846,7 +846,7 @@ class SubstrateInterface(SubstrateMixin):
             )
 
         runtime = get_runtime(block_hash)
-        self.runtime_cache.add_item(block_id, block_hash, runtime)
+        self.runtime_cache.add_item(block_hash=block_hash, runtime=runtime)
         return runtime
 
     def create_storage_key(

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -743,11 +743,11 @@ class SubstrateInterface(SubstrateMixin):
 
             # In fact calls and storage functions are decoded against runtime of previous block, therefore retrieve
             # metadata and apply type registry of runtime of parent block
-            block_header = self.rpc_request("chain_getHeader", [self.last_block_hash])
+            block_header = self.rpc_request("chain_getHeader", [block_hash])
 
             if block_header["result"] is None:
                 raise SubstrateRequestException(
-                    f'Block not found for "{self.last_block_hash}"'
+                    f'Block not found for "{block_hash}"'
                 )
             parent_block_hash: str = block_header["result"]["parentHash"]
 
@@ -755,7 +755,7 @@ class SubstrateInterface(SubstrateMixin):
                 parent_block_hash
                 == "0x0000000000000000000000000000000000000000000000000000000000000000"
             ):
-                runtime_block_hash = self.last_block_hash
+                runtime_block_hash = block_hash
             else:
                 runtime_block_hash = parent_block_hash
 

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -515,7 +515,6 @@ class SubstrateInterface(SubstrateMixin):
         self.metadata_version_hex = "0x0f000000"  # v15
         self.reload_type_registry()
         self.ws = self.connect(init=True)
-        self.registry_type_map = {}
         self.type_id_to_name = {}
         if not _mock:
             self.initialize()

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -714,6 +714,10 @@ class SubstrateInterface(SubstrateMixin):
         if block_id and block_hash:
             raise ValueError("Cannot provide block_hash and block_id at the same time")
 
+        runtime = self.runtime_cache.retrieve(block_id, block_hash)
+        if runtime and runtime.metadata is not None:
+            return runtime
+
         def get_runtime(block_hash, block_id) -> Runtime:
             # Check if runtime state already set to current block
             if (
@@ -842,10 +846,6 @@ class SubstrateInterface(SubstrateMixin):
                 metadata,
                 self.type_registry,
             )
-
-        runtime = self.runtime_cache.retrieve(block_id, block_hash)
-        if runtime and runtime.metadata is not None:
-            return runtime
 
         runtime = get_runtime(block_hash, block_id)
         self.runtime_cache.add_item(block_id, block_hash, runtime)

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -671,14 +671,17 @@ class SubstrateInterface(SubstrateMixin):
             metadata = self.get_block_metadata(),
         )
 
-    def load_runtime(self,runtime_info=None,metadata=None):
+    def load_runtime(self,runtime_info=None,metadata=None,metadata_v15=None):
         self.runtime_version = runtime_info.get("specVersion")
         self._metadata = metadata
         self._metadata_cache[self.runtime_version] = self._metadata
         self.runtime_config.set_active_spec_version_id(self.runtime_version)
         self.transaction_version = runtime_info.get("transactionVersion")
         if self.implements_scaleinfo:
+            logger.debug("Add PortableRegistry from metadata to type registry")
             self.runtime_config.add_portable_registry(metadata)
+        if metadata_v15 is not None:
+            self._old_metadata_v15 = metadata_v15
         # Set runtime compatibility flags
         try:
             _ = self.runtime_config.create_scale_object("sp_weights::weight_v2::Weight")
@@ -770,66 +773,52 @@ class SubstrateInterface(SubstrateMixin):
                     self.type_registry,
                 )
 
-            self.runtime_version = runtime_info.get("specVersion")
-            self.transaction_version = runtime_info.get("transactionVersion")
+            runtime_version = runtime_info.get("specVersion")
 
-            if not self._metadata:
-                if self.runtime_version in self._metadata_cache:
-                    # Get metadata from cache
-                    logger.debug(
-                        "Retrieved metadata for {} from memory".format(
-                            self.runtime_version
-                        )
+            if runtime_version in self._metadata_cache:
+                # Get metadata from cache
+                logger.debug(
+                    "Retrieved metadata for {} from memory".format(
+                        runtime_version
                     )
-                    metadata = self._metadata = self._metadata_cache[
-                        self.runtime_version
-                    ]
-                else:
-                    metadata = self._metadata = self.get_block_metadata(
-                        block_hash=runtime_block_hash, decode=True
-                    )
-                    logger.debug(
-                        "Retrieved metadata for {} from Substrate node".format(
-                            self.runtime_version
-                        )
-                    )
-
-                    # Update metadata cache
-                    self._metadata_cache[self.runtime_version] = self._metadata
+                )
+                metadata = self._metadata_cache[
+                    runtime_version
+                ]
             else:
-                metadata = self._metadata
+                metadata = self.get_block_metadata(
+                    block_hash=runtime_block_hash, decode=True
+                )
+                logger.debug(
+                    "Retrieved metadata for {} from Substrate node".format(
+                        runtime_version
+                    )
+                )
 
-            if self.runtime_version in self._metadata_v15_cache:
+            if runtime_version in self._metadata_v15_cache:
                 # Get metadata v15 from cache
                 logger.debug(
                     "Retrieved metadata v15 for {} from memory".format(
-                        self.runtime_version
+                        runtime_version
                     )
                 )
-                metadata_v15 = self._old_metadata_v15 = self._metadata_v15_cache[
-                    self.runtime_version
+                metadata_v15 = self._metadata_v15_cache[
+                    runtime_version
                 ]
             else:
-                metadata_v15 = self._old_metadata_v15 = self._load_registry_at_block(
+                metadata_v15 = self._load_registry_at_block(
                     block_hash=runtime_block_hash
                 )
                 logger.debug(
                     "Retrieved metadata v15 for {} from Substrate node".format(
-                        self.runtime_version
+                        runtime_version
                     )
                 )
                 # Update metadata v15 cache
-                self._metadata_v15_cache[self.runtime_version] = metadata_v15
+                self._metadata_v15_cache[runtime_version] = metadata_v15
 
             # Update type registry
             self.reload_type_registry(use_remote_preset=False, auto_discover=True)
-
-            if self.implements_scaleinfo:
-                logger.debug("Add PortableRegistry from metadata to type registry")
-                self.runtime_config.add_portable_registry(metadata)
-
-            # Set active runtime version
-            self.runtime_config.set_active_spec_version_id(self.runtime_version)
 
             # Check and apply runtime constants
             ss58_prefix_constant = self.get_constant(
@@ -839,18 +828,12 @@ class SubstrateInterface(SubstrateMixin):
             if ss58_prefix_constant:
                 self.ss58_format = ss58_prefix_constant
 
-            # Set runtime compatibility flags
-            try:
-                _ = self.runtime_config.create_scale_object(
-                    "sp_weights::weight_v2::Weight"
+            self.load_runtime(
+                    runtime_info=runtime_info,
+                    metadata=metadata,
+                    metadata_v15=metadata_v15,
                 )
-                self.config["is_weight_v2"] = True
-                self.runtime_config.update_type_registry_types(
-                    {"Weight": "sp_weights::weight_v2::Weight"}
-                )
-            except NotImplementedError:
-                self.config["is_weight_v2"] = False
-                self.runtime_config.update_type_registry_types({"Weight": "WeightV1"})
+
             return Runtime(
                 self.chain,
                 self.runtime_config,

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -844,12 +844,11 @@ class SubstrateInterface(SubstrateMixin):
             )
 
         runtime = self.runtime_cache.retrieve(block_id, block_hash)
-        if (
-            not runtime
-            or runtime.metadata is None
-        ):
-            runtime = get_runtime(block_hash, block_id)
-            self.runtime_cache.add_item(block_id, block_hash, runtime)
+        if runtime and runtime.metadata is not None:
+            return runtime
+
+        runtime = get_runtime(block_hash, block_id)
+        self.runtime_cache.add_item(block_id, block_hash, runtime)
         return runtime
 
     def create_storage_key(

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -2259,7 +2259,6 @@ class SubstrateInterface(SubstrateMixin):
             params = {}
 
         try:
-            self.registry = PortableRegistry.from_metadata_v15(self.metadata_v15)
             metadata_v15_value = self.metadata_v15.value()
 
             apis = {entry["name"]: entry for entry in metadata_v15_value["apis"]}

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -737,6 +737,9 @@ class SubstrateInterface(SubstrateMixin):
                 f"No runtime information for block '{block_hash}'"
             )
 
+        if runtime_version == self.runtime_version:
+            return
+
         runtime = self.runtime_cache.retrieve(runtime_version=runtime_version)
         if not runtime or runtime.metadata is None:
             self.last_block_hash = block_hash

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -584,7 +584,7 @@ class SubstrateInterface(SubstrateMixin):
 
     def get_storage_item(self, module: str, storage_function: str, block_hash: str = None):
         self.init_runtime(block_hash=block_hash)
-        metadata_pallet = self._metadata.get_metadata_pallet(module)
+        metadata_pallet = self.runtime.metadata.get_metadata_pallet(module)
         storage_item = metadata_pallet.get_storage_function(storage_function)
         return storage_item
 
@@ -610,9 +610,9 @@ class SubstrateInterface(SubstrateMixin):
         metadata_option_hex_str = metadata_rpc_result["result"]
         metadata_option_bytes = bytes.fromhex(metadata_option_hex_str[2:])
         metadata = MetadataV15.decode_from_metadata_option(metadata_option_bytes)
-        self.registry = PortableRegistry.from_metadata_v15(metadata)
-        self._load_registry_type_map()
-        return metadata
+        registry = PortableRegistry.from_metadata_v15(metadata)
+        self._load_registry_type_map(registry)
+        return metadata,registry
 
     def decode_scale(
         self,
@@ -637,25 +637,22 @@ class SubstrateInterface(SubstrateMixin):
             # Decode AccountId bytes to SS58 address
             return ss58_encode(scale_bytes, SS58_FORMAT)
         else:
-            obj = decode_by_type_string(type_string, self.registry, scale_bytes)
+            obj = decode_by_type_string(type_string, self.runtime.registry, scale_bytes)
         if return_scale_obj:
             return ScaleObj(obj)
         else:
             return obj
 
-    def load_runtime(self,runtime_info=None,metadata=None,metadata_v15=None,registry=None):
+    def load_runtime(self,runtime):
         # Update type registry
         self.reload_type_registry(use_remote_preset=False, auto_discover=True)
 
-        self.metadata_v15 = metadata_v15
-        self.registry = registry
-        self.runtime_version = runtime_info.get("specVersion")
-        self._metadata = metadata
-        self.runtime_config.set_active_spec_version_id(self.runtime_version)
-        self.transaction_version = runtime_info.get("transactionVersion")
+        self.runtime = runtime
+
+        self.runtime_config.set_active_spec_version_id(runtime.runtime_version)
         if self.implements_scaleinfo:
             logger.debug("Add PortableRegistry from metadata to type registry")
-            self.runtime_config.add_portable_registry(metadata)
+            self.runtime_config.add_portable_registry(runtime.metadata)
         # Set runtime compatibility flags
         try:
             _ = self.runtime_config.create_scale_object("sp_weights::weight_v2::Weight")
@@ -701,7 +698,7 @@ class SubstrateInterface(SubstrateMixin):
                 f"No runtime information for block '{block_hash}'"
             )
 
-        if runtime_version == self.runtime_version:
+        if self.runtime and runtime_version == self.runtime.runtime_version:
             return
 
         runtime = self.runtime_cache.retrieve(runtime_version=runtime_version)
@@ -726,7 +723,7 @@ class SubstrateInterface(SubstrateMixin):
                 )
             )
 
-            metadata_v15 = self._load_registry_at_block(
+            metadata_v15,registry = self._load_registry_at_block(
                 block_hash=runtime_block_hash
             )
             logger.debug(
@@ -742,16 +739,11 @@ class SubstrateInterface(SubstrateMixin):
                     type_registry=self.type_registry,
                     metadata_v15=metadata_v15,
                     runtime_info=runtime_info,
-                    registry=self.registry,
+                    registry=registry,
                 )
             self.runtime_cache.add_item(runtime_version=runtime_version, runtime=runtime)
 
-        self.load_runtime(
-                runtime_info=runtime.runtime_info,
-                metadata=runtime.metadata,
-                metadata_v15=runtime.metadata_v15,
-                registry=runtime.registry,
-            )
+        self.load_runtime(runtime)
 
         if self.ss58_format is None:
             # Check and apply runtime constants
@@ -788,7 +780,7 @@ class SubstrateInterface(SubstrateMixin):
             storage_function,
             params,
             runtime_config=self.runtime_config,
-            metadata=self._metadata,
+            metadata=self.runtime.metadata,
         )
 
     def get_metadata_storage_functions(self, block_hash=None) -> list:
@@ -813,7 +805,7 @@ class SubstrateInterface(SubstrateMixin):
                         self.serialize_storage_item(
                             storage_item=storage,
                             module=module,
-                            spec_version_id=self.runtime_version,
+                            spec_version_id=self.runtime.runtime_version,
                         )
                     )
 
@@ -852,14 +844,14 @@ class SubstrateInterface(SubstrateMixin):
 
         error_list = []
 
-        for module_idx, module in enumerate(self._metadata.pallets):
+        for module_idx, module in enumerate(self.runtime.metadata.pallets):
             if module.errors:
                 for error in module.errors:
                     error_list.append(
                         self.serialize_module_error(
                             module=module,
                             error=error,
-                            spec_version=self.runtime_version,
+                            spec_version=self.runtime.runtime_version,
                         )
                     )
 
@@ -880,7 +872,7 @@ class SubstrateInterface(SubstrateMixin):
         """
         self.init_runtime(block_hash=block_hash)
 
-        for module_idx, module in enumerate(self._metadata.pallets):
+        for module_idx, module in enumerate(self.runtime.metadata.pallets):
             if module.name == module_name and module.errors:
                 for error in module.errors:
                     if error_name == error.name:
@@ -973,7 +965,7 @@ class SubstrateInterface(SubstrateMixin):
                         try:
                             extrinsic_decoder = extrinsic_cls(
                                 data=ScaleBytes(extrinsic_data),
-                                metadata=self._metadata,
+                                metadata=self.runtime.metadata,
                                 runtime_config=self.runtime_config,
                             )
                             extrinsic_decoder.decode(check_remaining=True)
@@ -1495,7 +1487,7 @@ class SubstrateInterface(SubstrateMixin):
         """
         params = query_for if query_for else []
         # Search storage call in metadata
-        metadata_pallet = self._metadata.get_metadata_pallet(module)
+        metadata_pallet = self.runtime.metadata.get_metadata_pallet(module)
 
         if not metadata_pallet:
             raise SubstrateRequestException(f'Pallet "{module}" not found')
@@ -1530,7 +1522,7 @@ class SubstrateInterface(SubstrateMixin):
                 storage_item.value["name"],
                 params,
                 runtime_config=self.runtime_config,
-                metadata=self._metadata,
+                metadata=self.runtime.metadata,
             )
         method = "state_getStorageAt"
         return Preprocessed(
@@ -1777,7 +1769,7 @@ class SubstrateInterface(SubstrateMixin):
         self.init_runtime(block_hash=block_hash)
 
         call = self.runtime_config.create_scale_object(
-            type_string="Call", metadata=self._metadata
+            type_string="Call", metadata=self.runtime.metadata
         )
 
         call.encode(
@@ -1946,12 +1938,12 @@ class SubstrateInterface(SubstrateMixin):
         )
 
         # Process signed extensions in metadata
-        if "signed_extensions" in self._metadata[1][1]["extrinsic"]:
+        if "signed_extensions" in self.runtime.metadata[1][1]["extrinsic"]:
             # Base signature payload
             signature_payload.type_mapping = [["call", "CallBytes"]]
 
             # Add signed extensions to payload
-            signed_extensions = self._metadata.get_signed_extensions()
+            signed_extensions = self.runtime.metadata.get_signed_extensions()
 
             if "CheckMortality" in signed_extensions:
                 signature_payload.type_mapping.append(
@@ -2040,10 +2032,10 @@ class SubstrateInterface(SubstrateMixin):
             "era": era,
             "nonce": nonce,
             "tip": tip,
-            "spec_version": self.runtime_version,
+            "spec_version": self.runtime.runtime_version,
             "genesis_hash": genesis_hash,
             "block_hash": block_hash,
-            "transaction_version": self.transaction_version,
+            "transaction_version": self.runtime.transaction_version,
             "asset_id": {"tip": tip, "asset_id": tip_asset_id},
             "metadata_hash": None,
             "mode": "Disabled",
@@ -2092,9 +2084,9 @@ class SubstrateInterface(SubstrateMixin):
             raise TypeError("'call' must be of type Call")
 
         # Check if extrinsic version is supported
-        if self._metadata[1][1]["extrinsic"]["version"] != 4:  # type: ignore
+        if self.runtime.metadata[1][1]["extrinsic"]["version"] != 4:  # type: ignore
             raise NotImplementedError(
-                f"Extrinsic version {self._metadata[1][1]['extrinsic']['version']} not supported"  # type: ignore
+                f"Extrinsic version {self.runtime.metadata[1][1]['extrinsic']['version']} not supported"  # type: ignore
             )
 
         # Retrieve nonce
@@ -2134,7 +2126,7 @@ class SubstrateInterface(SubstrateMixin):
 
         # Create extrinsic
         extrinsic = self.runtime_config.create_scale_object(
-            type_string="Extrinsic", metadata=self._metadata
+            type_string="Extrinsic", metadata=self.runtime.metadata
         )
 
         value = {
@@ -2248,7 +2240,7 @@ class SubstrateInterface(SubstrateMixin):
             params = {}
 
         try:
-            metadata_v15_value = self.metadata_v15.value()
+            metadata_v15_value = self.runtime.metadata_v15.value()
 
             apis = {entry["name"]: entry for entry in metadata_v15_value["apis"]}
             api_entry = apis[api]
@@ -2347,7 +2339,7 @@ class SubstrateInterface(SubstrateMixin):
         """
         self.init_runtime(block_hash=block_hash)
 
-        for module in self._metadata.pallets:
+        for module in self.runtime.metadata.pallets:
             if module_name == module.name and module.constants:
                 for constant in module.constants:
                     if constant_name == constant.value["name"]:
@@ -2490,7 +2482,7 @@ class SubstrateInterface(SubstrateMixin):
                 "metadata_index": idx,
                 "module_id": module.get_identifier(),
                 "name": module.name,
-                "spec_version": self.runtime_version,
+                "spec_version": self.runtime.runtime_version,
                 "count_call_functions": len(module.calls or []),
                 "count_storage_functions": len(module.storage or []),
                 "count_events": len(module.events or []),
@@ -2607,7 +2599,7 @@ class SubstrateInterface(SubstrateMixin):
             self.last_block_hash = block_hash
         self.init_runtime(block_hash=block_hash)
 
-        metadata_pallet = self._metadata.get_metadata_pallet(module)
+        metadata_pallet = self.runtime.metadata.get_metadata_pallet(module)
         if not metadata_pallet:
             raise ValueError(f'Pallet "{module}" not found')
         storage_item = metadata_pallet.get_storage_function(storage_function)
@@ -2636,7 +2628,7 @@ class SubstrateInterface(SubstrateMixin):
             storage_item.value["name"],
             params,
             runtime_config=self.runtime_config,
-            metadata=self._metadata,
+            metadata=self.runtime.metadata,
         )
         prefix = storage_key.to_hex()
 

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -741,7 +741,7 @@ class SubstrateInterface(SubstrateMixin):
             return
 
         runtime = self.runtime_cache.retrieve(runtime_version=runtime_version)
-        if not runtime or runtime.metadata is None:
+        if not runtime:
             self.last_block_hash = block_hash
 
             runtime_block_hash = self.get_parent_block_hash(block_hash)
@@ -751,6 +751,11 @@ class SubstrateInterface(SubstrateMixin):
             metadata = self.get_block_metadata(
                 block_hash=runtime_block_hash, decode=True
             )
+            if metadata is None:
+                # does this ever happen?
+                raise SubstrateRequestException(
+                    f"No metadata for block '{runtime_block_hash}'"
+                )
             logger.debug(
                 "Retrieved metadata for {} from Substrate node".format(
                     runtime_version

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -763,12 +763,6 @@ class SubstrateInterface(SubstrateMixin):
                 )
             )
 
-            self.load_runtime(
-                    runtime_info=runtime_info,
-                    metadata=metadata,
-                    metadata_v15=metadata_v15,
-                )
-
             runtime = Runtime(
                     chain=self.chain,
                     runtime_config=self.runtime_config,
@@ -778,6 +772,13 @@ class SubstrateInterface(SubstrateMixin):
                     runtime_info=runtime_info,
                 )
             self.runtime_cache.add_item(runtime_version=runtime_version, runtime=runtime)
+
+        self.load_runtime(
+                runtime_info=runtime.runtime_info,
+                metadata=runtime.metadata,
+                metadata_v15=runtime.metadata_v15,
+            )
+
         return runtime
 
     def create_storage_key(

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -743,21 +743,7 @@ class SubstrateInterface(SubstrateMixin):
 
             # In fact calls and storage functions are decoded against runtime of previous block, therefore retrieve
             # metadata and apply type registry of runtime of parent block
-            block_header = self.rpc_request("chain_getHeader", [block_hash])
-
-            if block_header["result"] is None:
-                raise SubstrateRequestException(
-                    f'Block not found for "{block_hash}"'
-                )
-            parent_block_hash: str = block_header["result"]["parentHash"]
-
-            if (
-                parent_block_hash
-                == "0x0000000000000000000000000000000000000000000000000000000000000000"
-            ):
-                runtime_block_hash = block_hash
-            else:
-                runtime_block_hash = parent_block_hash
+            runtime_block_hash = self.get_parent_block_hash(block_hash)
 
             runtime_info = self.get_block_runtime_version(block_hash=runtime_block_hash)
 
@@ -1497,6 +1483,20 @@ class SubstrateInterface(SubstrateMixin):
             for item in list(storage_obj):
                 events.append(convert_event_data(item))
         return events
+
+    def get_parent_block_hash(self,block_hash):
+        block_header = self.rpc_request("chain_getHeader", [block_hash])
+
+        if block_header["result"] is None:
+            raise SubstrateRequestException(
+                f'Block not found for "{block_hash}"'
+            )
+        parent_block_hash: str = block_header["result"]["parentHash"]
+
+        if int(parent_block_hash,16) == 0:
+            # "0x0000000000000000000000000000000000000000000000000000000000000000"
+            return block_hash
+        return parent_block_hash
 
     def get_block_runtime_version(self, block_hash: str) -> dict:
         """

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -512,8 +512,6 @@ class SubstrateInterface(SubstrateMixin):
         self.runtime_config = RuntimeConfigurationObject(
             ss58_format=self.ss58_format, implements_scale_info=True
         )
-        self._metadata_cache = {}
-        self._metadata_v15_cache = {}
         self._old_metadata_v15 = None
         self.metadata_version_hex = "0x0f000000"  # v15
         self.reload_type_registry()
@@ -684,7 +682,6 @@ class SubstrateInterface(SubstrateMixin):
 
         self.runtime_version = runtime_info.get("specVersion")
         self._metadata = metadata
-        self._metadata_cache[self.runtime_version] = self._metadata
         self.runtime_config.set_active_spec_version_id(self.runtime_version)
         self.transaction_version = runtime_info.get("transactionVersion")
         if self.implements_scaleinfo:

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -670,7 +670,18 @@ class SubstrateInterface(SubstrateMixin):
             metadata = self.get_block_metadata(),
         )
 
+        # Check and apply runtime constants
+        ss58_prefix_constant = self.get_constant(
+            "System", "SS58Prefix"
+        )
+
+        if ss58_prefix_constant:
+            self.ss58_format = ss58_prefix_constant
+
     def load_runtime(self,runtime_info=None,metadata=None,metadata_v15=None):
+        # Update type registry
+        self.reload_type_registry(use_remote_preset=False, auto_discover=True)
+
         self.runtime_version = runtime_info.get("specVersion")
         self._metadata = metadata
         self._metadata_cache[self.runtime_version] = self._metadata
@@ -778,17 +789,6 @@ class SubstrateInterface(SubstrateMixin):
                 )
                 # Update metadata v15 cache
                 self._metadata_v15_cache[runtime_version] = metadata_v15
-
-            # Update type registry
-            self.reload_type_registry(use_remote_preset=False, auto_discover=True)
-
-            # Check and apply runtime constants
-            ss58_prefix_constant = self.get_constant(
-                "System", "SS58Prefix", block_hash=block_hash
-            )
-
-            if ss58_prefix_constant:
-                self.ss58_format = ss58_prefix_constant
 
             self.load_runtime(
                     runtime_info=runtime_info,

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -644,10 +644,10 @@ class SubstrateInterface(SubstrateMixin):
             return obj
 
     def load_runtime(self,runtime):
+        self.runtime = runtime
+
         # Update type registry
         self.reload_type_registry(use_remote_preset=False, auto_discover=True)
-
-        self.runtime = runtime
 
         self.runtime_config.set_active_spec_version_id(runtime.runtime_version)
         if self.implements_scaleinfo:

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -604,19 +604,11 @@ class SubstrateInterface(SubstrateMixin):
 
     def load_registry(self):
         # This needs to happen before init_runtime
-        metadata_rpc_result = self.rpc_request(
-            "state_call",
-            ["Metadata_metadata_at_version", self.metadata_version_hex],
-        )
-        metadata_option_hex_str = metadata_rpc_result["result"]
-        metadata_option_bytes = bytes.fromhex(metadata_option_hex_str[2:])
-        self.metadata_v15 = MetadataV15.decode_from_metadata_option(
-            metadata_option_bytes
-        )
+        self.metadata_v15 = self._load_registry_at_block(None)
         self.registry = PortableRegistry.from_metadata_v15(self.metadata_v15)
         self._load_registry_type_map()
 
-    def _load_registry_at_block(self, block_hash: str) -> MetadataV15:
+    def _load_registry_at_block(self, block_hash: Optional[str]) -> MetadataV15:
         # Should be called for any block that fails decoding.
         # Possibly the metadata was different.
         metadata_rpc_result = self.rpc_request(
@@ -626,9 +618,8 @@ class SubstrateInterface(SubstrateMixin):
         )
         metadata_option_hex_str = metadata_rpc_result["result"]
         metadata_option_bytes = bytes.fromhex(metadata_option_hex_str[2:])
-        old_metadata = MetadataV15.decode_from_metadata_option(metadata_option_bytes)
-
-        return old_metadata
+        metadata = MetadataV15.decode_from_metadata_option(metadata_option_bytes)
+        return metadata
 
     def decode_scale(
         self,

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -738,10 +738,7 @@ class SubstrateInterface(SubstrateMixin):
             )
 
         runtime = self.runtime_cache.retrieve(runtime_version=runtime_version)
-        if runtime and runtime.metadata is not None:
-            return runtime
-
-        if True: # keep indenting, this used to be a local function
+        if not runtime or runtime.metadata is None:
             self.last_block_hash = block_hash
 
             runtime_block_hash = self.get_parent_block_hash(block_hash)
@@ -772,15 +769,15 @@ class SubstrateInterface(SubstrateMixin):
                     metadata_v15=metadata_v15,
                 )
 
-        runtime = Runtime(
-                chain=self.chain,
-                runtime_config=self.runtime_config,
-                metadata=metadata,
-                type_registry=self.type_registry,
-                metadata_v15=metadata_v15,
-                runtime_info=runtime_info,
-            )
-        self.runtime_cache.add_item(runtime_version=runtime_version, runtime=runtime)
+            runtime = Runtime(
+                    chain=self.chain,
+                    runtime_config=self.runtime_config,
+                    metadata=metadata,
+                    type_registry=self.type_registry,
+                    metadata_v15=metadata_v15,
+                    runtime_info=runtime_info,
+                )
+            self.runtime_cache.add_item(runtime_version=runtime_version, runtime=runtime)
         return runtime
 
     def create_storage_key(

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -1794,6 +1794,7 @@ class SubstrateInterface(SubstrateMixin):
         else:
             raise SubstrateRequestException(result[payload_id][0])
 
+    @lru_cache(maxsize=512) # block_id->block_hash does not change
     def get_block_hash(self, block_id: int) -> str:
         return self.rpc_request("chain_getBlockHash", [block_id])["result"]
 

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -748,47 +748,23 @@ class SubstrateInterface(SubstrateMixin):
 
             runtime_info = self.get_block_runtime_info(runtime_block_hash)
 
-            if runtime_version in self._metadata_cache:
-                # Get metadata from cache
-                logger.debug(
-                    "Retrieved metadata for {} from memory".format(
-                        runtime_version
-                    )
-                )
-                metadata = self._metadata_cache[
+            metadata = self.get_block_metadata(
+                block_hash=runtime_block_hash, decode=True
+            )
+            logger.debug(
+                "Retrieved metadata for {} from Substrate node".format(
                     runtime_version
-                ]
-            else:
-                metadata = self.get_block_metadata(
-                    block_hash=runtime_block_hash, decode=True
                 )
-                logger.debug(
-                    "Retrieved metadata for {} from Substrate node".format(
-                        runtime_version
-                    )
-                )
+            )
 
-            if runtime_version in self._metadata_v15_cache:
-                # Get metadata v15 from cache
-                logger.debug(
-                    "Retrieved metadata v15 for {} from memory".format(
-                        runtime_version
-                    )
-                )
-                metadata_v15 = self._metadata_v15_cache[
+            metadata_v15 = self._load_registry_at_block(
+                block_hash=runtime_block_hash
+            )
+            logger.debug(
+                "Retrieved metadata v15 for {} from Substrate node".format(
                     runtime_version
-                ]
-            else:
-                metadata_v15 = self._load_registry_at_block(
-                    block_hash=runtime_block_hash
                 )
-                logger.debug(
-                    "Retrieved metadata v15 for {} from Substrate node".format(
-                        runtime_version
-                    )
-                )
-                # Update metadata v15 cache
-                self._metadata_v15_cache[runtime_version] = metadata_v15
+            )
 
             self.load_runtime(
                     runtime_info=runtime_info,

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -782,8 +782,6 @@ class SubstrateInterface(SubstrateMixin):
                 metadata_v15=runtime.metadata_v15,
             )
 
-        return runtime
-
     def create_storage_key(
         self,
         pallet: str,
@@ -1923,10 +1921,10 @@ class SubstrateInterface(SubstrateMixin):
         Returns:
              The created Scale Type object
         """
-        runtime = self.init_runtime(block_hash=block_hash)
+        self.init_runtime(block_hash=block_hash)
 
         if "metadata" not in kwargs:
-            kwargs["metadata"] = runtime.metadata
+            kwargs["metadata"] = self.runtime.metadata
 
         return runtime.runtime_config.create_scale_object(
             type_string, data=data, **kwargs
@@ -2896,9 +2894,9 @@ class SubstrateInterface(SubstrateMixin):
         Returns:
             list of call functions
         """
-        runtime = self.init_runtime(block_hash=block_hash)
+        self.init_runtime(block_hash=block_hash)
 
-        for pallet in runtime.metadata.pallets:
+        for pallet in self.runtime.metadata.pallets:
             if pallet.name == module_name and pallet.calls:
                 for call in pallet.calls:
                     if call.name == call_function_name:

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -711,6 +711,9 @@ class SubstrateInterface(SubstrateMixin):
             Runtime object
         """
 
+        if block_id and block_hash:
+            raise ValueError("Cannot provide block_hash and block_id at the same time")
+
         def get_runtime(block_hash, block_id) -> Runtime:
             # Check if runtime state already set to current block
             if (
@@ -840,11 +843,9 @@ class SubstrateInterface(SubstrateMixin):
                 self.type_registry,
             )
 
-        if block_id and block_hash:
-            raise ValueError("Cannot provide block_hash and block_id at the same time")
-
+        runtime = self.runtime_cache.retrieve(block_id, block_hash)
         if (
-            not (runtime := self.runtime_cache.retrieve(block_id, block_hash))
+            not runtime
             or runtime.metadata is None
         ):
             runtime = get_runtime(block_hash, block_id)

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -666,11 +666,15 @@ class SubstrateInterface(SubstrateMixin):
         """
         TODO docstring
         """
-        runtime_info = self.get_block_runtime_version(None)
-        metadata = self.get_block_metadata()
+        self.load_runtime(
+            runtime_info = self.get_block_runtime_version(None),
+            metadata = self.get_block_metadata(),
+        )
+
+    def load_runtime(self,runtime_info=None,metadata=None):
+        self.runtime_version = runtime_info.get("specVersion")
         self._metadata = metadata
         self._metadata_cache[self.runtime_version] = self._metadata
-        self.runtime_version = runtime_info.get("specVersion")
         self.runtime_config.set_active_spec_version_id(self.runtime_version)
         self.transaction_version = runtime_info.get("transactionVersion")
         if self.implements_scaleinfo:

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -731,33 +731,7 @@ class SubstrateInterface(SubstrateMixin):
             return runtime
 
         def get_runtime(block_hash,runtime_version) -> Runtime:
-            # Check if runtime state already set to current block
-            if (
-                block_hash and block_hash == self.last_block_hash
-            ) and all(
-                x is not None
-                for x in [self._metadata, self._old_metadata_v15, self.metadata_v15]
-            ):
-                return Runtime(
-                    self.chain,
-                    self.runtime_config,
-                    self._metadata,
-                    self.type_registry,
-                )
-
             self.last_block_hash = block_hash
-
-            # Check if runtime state already set to current block
-            if runtime_version == self.runtime_version and all(
-                x is not None
-                for x in [self._metadata, self._old_metadata_v15, self.metadata_v15]
-            ):
-                return Runtime(
-                    self.chain,
-                    self.runtime_config,
-                    self._metadata,
-                    self.type_registry,
-                )
 
             runtime_block_hash = self.get_parent_block_hash(block_hash)
 

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -730,7 +730,7 @@ class SubstrateInterface(SubstrateMixin):
         if runtime and runtime.metadata is not None:
             return runtime
 
-        def get_runtime(block_hash,runtime_version) -> Runtime:
+        if True: # keep indenting, this used to be a local function
             self.last_block_hash = block_hash
 
             runtime_block_hash = self.get_parent_block_hash(block_hash)
@@ -796,14 +796,12 @@ class SubstrateInterface(SubstrateMixin):
                     metadata_v15=metadata_v15,
                 )
 
-            return Runtime(
+        runtime = Runtime(
                 self.chain,
                 self.runtime_config,
                 metadata,
                 self.type_registry,
             )
-
-        runtime = get_runtime(block_hash,runtime_version)
         self.runtime_cache.add_item(runtime_version=runtime_version, runtime=runtime)
         return runtime
 

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -70,9 +70,10 @@ class Runtime:
     runtime_config: RuntimeConfigurationObject
     runtime_info = None
     type_registry_preset = None
+    registry: Optional[PortableRegistry] = None
 
     def __init__(
-        self, chain, runtime_config: RuntimeConfigurationObject, metadata, type_registry, metadata_v15=None, runtime_info=None
+        self, chain, runtime_config: RuntimeConfigurationObject, metadata, type_registry, metadata_v15=None, runtime_info=None, registry=None
     ):
         self.config = {}
         self.chain = chain
@@ -81,6 +82,7 @@ class Runtime:
         self.metadata = metadata
         self.metadata_v15 = metadata_v15
         self.runtime_info = runtime_info
+        self.registry = registry
 
     def __str__(self):
         return f"Runtime: {self.chain} | {self.config}"

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -87,93 +87,92 @@ class Runtime:
     def __str__(self):
         return f"Runtime: {self.chain} | {self.config}"
 
-    @property
-    def implements_scaleinfo(self) -> bool:
-        """
-        Returns True if current runtime implementation a `PortableRegistry` (`MetadataV14` and higher)
-        """
-        if self.metadata:
-            return self.metadata.portable_registry is not None
-        else:
-            return False
-
-    def reload_type_registry(
-        self, use_remote_preset: bool = True, auto_discover: bool = True
-    ):
-        """
-        Reload type registry and preset used to instantiate the SubstrateInterface object. Useful to periodically apply
-        changes in type definitions when a runtime upgrade occurred
-
-        Args:
-            use_remote_preset: When True preset is downloaded from Github master, otherwise use files from local
-                installed scalecodec package
-            auto_discover: Whether to automatically discover the type registry presets based on the chain name and the
-                type registry
-        """
-        self.runtime_config.clear_type_registry()
-
-        self.runtime_config.implements_scale_info = self.implements_scaleinfo
-
-        # Load metadata types in runtime configuration
-        self.runtime_config.update_type_registry(load_type_registry_preset(name="core"))
-        self.apply_type_registry_presets(
-            use_remote_preset=use_remote_preset, auto_discover=auto_discover
-        )
-
-    def apply_type_registry_presets(
-        self,
-        use_remote_preset: bool = True,
-        auto_discover: bool = True,
-    ):
-        """
-        Applies type registry presets to the runtime
-
-        Args:
-            use_remote_preset: whether to use presets from remote
-            auto_discover: whether to use presets from local installed scalecodec package
-        """
-        if self.type_registry_preset is not None:
-            # Load type registry according to preset
-            type_registry_preset_dict = load_type_registry_preset(
-                name=self.type_registry_preset, use_remote_preset=use_remote_preset
-            )
-
-            if not type_registry_preset_dict:
-                raise ValueError(
-                    f"Type registry preset '{self.type_registry_preset}' not found"
-                )
-
-        elif auto_discover:
-            # Try to auto discover type registry preset by chain name
-            type_registry_name = self.chain.lower().replace(" ", "-")
-            try:
-                type_registry_preset_dict = load_type_registry_preset(
-                    type_registry_name
-                )
-                self.type_registry_preset = type_registry_name
-            except ValueError:
-                type_registry_preset_dict = None
-
-        else:
-            type_registry_preset_dict = None
-
-        if type_registry_preset_dict:
-            # Load type registries in runtime configuration
-            if self.implements_scaleinfo is False:
-                # Only runtime with no embedded types in metadata need the default set of explicit defined types
-                self.runtime_config.update_type_registry(
-                    load_type_registry_preset(
-                        "legacy", use_remote_preset=use_remote_preset
-                    )
-                )
-
-            if self.type_registry_preset != "legacy":
-                self.runtime_config.update_type_registry(type_registry_preset_dict)
-
-        if self.type_registry:
-            # Load type registries in runtime configuration
-            self.runtime_config.update_type_registry(self.type_registry)
-
+#    @property
+#    def implements_scaleinfo(self) -> bool:
+#        """
+#        Returns True if current runtime implementation a `PortableRegistry` (`MetadataV14` and higher)
+#        """
+#        if self.metadata:
+#            return self.metadata.portable_registry is not None
+#        else:
+#            return False
+#
+#    def reload_type_registry(
+#        self, use_remote_preset: bool = True, auto_discover: bool = True
+#    ):
+#        """
+#        Reload type registry and preset used to instantiate the SubstrateInterface object. Useful to periodically apply
+#        changes in type definitions when a runtime upgrade occurred
+#
+#        Args:
+#            use_remote_preset: When True preset is downloaded from Github master, otherwise use files from local
+#                installed scalecodec package
+#            auto_discover: Whether to automatically discover the type registry presets based on the chain name and the
+#                type registry
+#        """
+#        self.runtime_config.clear_type_registry()
+#
+#        self.runtime_config.implements_scale_info = self.implements_scaleinfo
+#
+#        # Load metadata types in runtime configuration
+#        self.runtime_config.update_type_registry(load_type_registry_preset(name="core"))
+#        self.apply_type_registry_presets(
+#            use_remote_preset=use_remote_preset, auto_discover=auto_discover
+#        )
+#
+#    def apply_type_registry_presets(
+#        self,
+#        use_remote_preset: bool = True,
+#        auto_discover: bool = True,
+#    ):
+#        """
+#        Applies type registry presets to the runtime
+#
+#        Args:
+#            use_remote_preset: whether to use presets from remote
+#            auto_discover: whether to use presets from local installed scalecodec package
+#        """
+#        if self.type_registry_preset is not None:
+#            # Load type registry according to preset
+#            type_registry_preset_dict = load_type_registry_preset(
+#                name=self.type_registry_preset, use_remote_preset=use_remote_preset
+#            )
+#
+#            if not type_registry_preset_dict:
+#                raise ValueError(
+#                    f"Type registry preset '{self.type_registry_preset}' not found"
+#                )
+#
+#        elif auto_discover:
+#            # Try to auto discover type registry preset by chain name
+#            type_registry_name = self.chain.lower().replace(" ", "-")
+#            try:
+#                type_registry_preset_dict = load_type_registry_preset(
+#                    type_registry_name
+#                )
+#                self.type_registry_preset = type_registry_name
+#            except ValueError:
+#                type_registry_preset_dict = None
+#
+#        else:
+#            type_registry_preset_dict = None
+#
+#        if type_registry_preset_dict:
+#            # Load type registries in runtime configuration
+#            if self.implements_scaleinfo is False:
+#                # Only runtime with no embedded types in metadata need the default set of explicit defined types
+#                self.runtime_config.update_type_registry(
+#                    load_type_registry_preset(
+#                        "legacy", use_remote_preset=use_remote_preset
+#                    )
+#                )
+#
+#            if self.type_registry_preset != "legacy":
+#                self.runtime_config.update_type_registry(type_registry_preset_dict)
+#
+#        if self.type_registry:
+#            # Load type registries in runtime configuration
+#            self.runtime_config.update_type_registry(self.type_registry)
 
 class RequestManager:
     RequestResults = dict[Union[str, int], list[Union[ScaleType, dict]]]

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -370,7 +370,7 @@ class SubstrateMixin(ABC):
     type_registry: Optional[dict]
     ss58_format: Optional[int]
     ws_max_size = 2**32
-    registry_type_map: dict[str, int]
+    registry_type_map: dict[str, int] = {}
     type_id_to_name: dict[int, str]
     metadata_v15 = None
 

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -66,17 +66,21 @@ class Runtime:
     transaction_version = None
     cache_region = None
     metadata = None
+    metadata_v15 = None
     runtime_config: RuntimeConfigurationObject
+    runtime_info = None
     type_registry_preset = None
 
     def __init__(
-        self, chain, runtime_config: RuntimeConfigurationObject, metadata, type_registry
+        self, chain, runtime_config: RuntimeConfigurationObject, metadata, type_registry, metadata_v15=None, runtime_info=None
     ):
         self.config = {}
         self.chain = chain
         self.type_registry = type_registry
         self.runtime_config = runtime_config
         self.metadata = metadata
+        self.metadata_v15 = metadata_v15
+        self.runtime_info = runtime_info
 
     def __str__(self):
         return f"Runtime: {self.chain} | {self.config}"

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -60,8 +60,6 @@ class RuntimeCache:
 
 
 class Runtime:
-    block_hash: str
-    block_id: int
     runtime_version = None
     transaction_version = None
     cache_region = None
@@ -356,7 +354,6 @@ class ScaleObj:
 class SubstrateMixin(ABC):
     type_registry_preset = None
     transaction_version = None
-    block_id: Optional[int] = None
     last_block_hash: Optional[str] = None
     _name: Optional[str] = None
     _properties = None

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -22,26 +22,39 @@ logger = logging.getLogger("async_substrate_interface")
 class RuntimeCache:
     blocks: dict[int, "Runtime"]
     block_hashes: dict[str, "Runtime"]
+    versions: dict[int, "Runtime"]
 
     def __init__(self):
         self.blocks = {}
         self.block_hashes = {}
+        self.versions = {}
 
     def add_item(
-        self, block: Optional[int], block_hash: Optional[str], runtime: "Runtime"
+        self,
+        runtime: "Runtime",
+        block: Optional[int] = None,
+        block_hash: Optional[str] = None,
+        runtime_version: Optional[int] = None,
     ):
         if block is not None:
             self.blocks[block] = runtime
         if block_hash is not None:
             self.block_hashes[block_hash] = runtime
+        if runtime_version is not None:
+            self.versions[runtime_version] = runtime
 
     def retrieve(
-        self, block: Optional[int] = None, block_hash: Optional[str] = None
+        self,
+        block: Optional[int] = None,
+        block_hash: Optional[str] = None,
+        runtime_version: Optional[int] = None
     ) -> Optional["Runtime"]:
         if block is not None:
             return self.blocks.get(block)
         elif block_hash is not None:
             return self.block_hashes.get(block_hash)
+        elif runtime_version is not None:
+            return self.versions.get(runtime_version)
         else:
             return None
 

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -83,6 +83,8 @@ class Runtime:
         self.metadata_v15 = metadata_v15
         self.runtime_info = runtime_info
         self.registry = registry
+        self.runtime_version = runtime_info.get('specVersion')
+        self.transaction_version = runtime_info.get("transactionVersion")
 
     def __str__(self):
         return f"Runtime: {self.chain} | {self.config}"
@@ -352,8 +354,6 @@ class ScaleObj:
 
 
 class SubstrateMixin(ABC):
-    registry: Optional[PortableRegistry] = None
-    runtime_version = None
     type_registry_preset = None
     transaction_version = None
     block_id: Optional[int] = None
@@ -363,8 +363,6 @@ class SubstrateMixin(ABC):
     _version = None
     _token_decimals = None
     _token_symbol = None
-    _metadata = None
-    metadata_v15 = None
     _chain: str
     runtime_config: RuntimeConfigurationObject
     type_registry: Optional[dict]
@@ -372,7 +370,7 @@ class SubstrateMixin(ABC):
     ws_max_size = 2**32
     registry_type_map: dict[str, int] = {}
     type_id_to_name: dict[int, str]
-    metadata_v15 = None
+    runtime: Runtime = None
 
     @property
     def chain(self):
@@ -383,22 +381,13 @@ class SubstrateMixin(ABC):
 
     @property
     def metadata(self):
-        if self._metadata is None:
+        if not self.runtime or self.runtime.metadata is None:
             raise AttributeError(
                 "Metadata not found. This generally indicates that the AsyncSubstrateInterface object "
                 "is not properly async initialized."
             )
         else:
-            return self._metadata
-
-    @property
-    def runtime(self):
-        return Runtime(
-            self.chain,
-            self.runtime_config,
-            self._metadata,
-            self.type_registry,
-        )
+            return self.runtime.metadata
 
     @property
     def implements_scaleinfo(self) -> Optional[bool]:
@@ -409,8 +398,8 @@ class SubstrateMixin(ABC):
         -------
         bool
         """
-        if self._metadata:
-            return self._metadata.portable_registry is not None
+        if self.runtime and self.runtime.metadata:
+            return self.runtime.metadata.portable_registry is not None
         else:
             return None
 
@@ -628,10 +617,10 @@ class SubstrateMixin(ABC):
             "spec_version": spec_version,
         }
 
-    def _load_registry_type_map(self):
+    def _load_registry_type_map(self,registry):
         registry_type_map = {}
         type_id_to_name = {}
-        types = json.loads(self.registry.registry)["types"]
+        types = json.loads(registry.registry)["types"]
         for type_entry in types:
             type_type = type_entry["type"]
             type_id = type_entry["id"]

--- a/test_old_new.py
+++ b/test_old_new.py
@@ -1,0 +1,28 @@
+import sys
+import bittensor as bt
+st = bt.subtensor(network='local')
+print("ss58 format:",st.substrate.ss58_format)
+print("current block:",st.block)
+
+coldkey = '5HHHHHzgLnYRvnKkHd45cRUDMHXTSwx7MjUzxBrKbY4JfZWn'
+
+# dtao epoch is 4920350
+
+b_pre = 4920340
+b_post = 4920360
+
+n=3
+if len(sys.argv)>1:
+    n = int(sys.argv[1])
+
+for i in range(n):
+    s0 = st.get_stake_for_coldkey(coldkey,block=b_post+i)
+    print(f'at block {b_post+i}: {s0}')
+for i in range(n):
+    s1 = st.query_subtensor("TotalColdkeyStake",b_pre+i,[coldkey]).value
+    print(f'at block {b_pre+i}: {s1}')
+for i in range(n):
+    s2 = st.get_stake_for_coldkey(coldkey,block=b_post+i)
+    print(f'at block {b_post+i}: {s2}')
+
+


### PR DESCRIPTION
First draft of reworked async_substrate_interface/sync_substrate.py

Awaiting feedback before reworking async_substrate.py

Please find a simple testcase in test_old_new.py (maybe change network to finney) which demonstrates that without the fix, switching between blocks pre- and post-dtao leads to errors.

In total, a lot has changed, but the changes are done step by step in a lot of small commits, such that the thought process can be followed. In case something breaks, this should also help to narrow down the breaking change.

Until `b9dd0101b4ed36c74e92351cf4652034eb718957` it is mostly refactoring, at which point the bug is pretty obvious, and fixed.

The refactoring boils down to pushing all runtime_version related items to the runtime object, which is cached. The cache uses `runtime_version` as key (so not `block_hash`), while additional caching is done at the point where the runtime_version is looked up for a block_hash/block_id.

Further simplifications and cleanup are possible, but first let's see how this works out.