### PR TITLE
Feat/mvds00/runtime version fixes

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -966,6 +966,9 @@ class AsyncSubstrateInterface(SubstrateMixin):
             Runtime object
         """
 
+        if block_id and block_hash:
+            raise ValueError("Cannot provide block_hash and block_id at the same time")
+
         async def get_runtime(block_hash, block_id) -> Runtime:
             # Check if runtime state already set to current block
             if (
@@ -1103,16 +1106,14 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 self.type_registry,
             )
 
-        if block_id and block_hash:
-            raise ValueError("Cannot provide block_hash and block_id at the same time")
-
         if not self.metadata_v15:
             raise SubstrateRequestException(
                 "Metadata V15 was not loaded. This usually indicates that you did not correctly initialize"
                 " the AsyncSubstrateInterface class with `async with` or by calling `initialize()`"
             )
+        runtime = self.runtime_cache.retrieve(block_id, block_hash)
         if (
-            not (runtime := self.runtime_cache.retrieve(block_id, block_hash))
+            not runtime
             or runtime.metadata is None
         ):
             runtime = await get_runtime(block_hash, block_id)

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -924,9 +924,12 @@ class AsyncSubstrateInterface(SubstrateMixin):
         runtime_info, metadata = await asyncio.gather(
             self.get_block_runtime_version(None), self.get_block_metadata()
         )
+        await self.load_runtime(runtime_info=runtime_info, metadata=metadata)
+
+    async def load_runtime(self,runtime_info,metadata):
+        self.runtime_version = runtime_info.get("specVersion")
         self._metadata = metadata
         self._metadata_cache[self.runtime_version] = self._metadata
-        self.runtime_version = runtime_info.get("specVersion")
         self.runtime_config.set_active_spec_version_id(self.runtime_version)
         self.transaction_version = runtime_info.get("transactionVersion")
         if self.implements_scaleinfo:

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -999,12 +999,12 @@ class AsyncSubstrateInterface(SubstrateMixin):
             # In fact calls and storage functions are decoded against runtime of previous block, therefore retrieve
             # metadata and apply type registry of runtime of parent block
             block_header = await self.rpc_request(
-                "chain_getHeader", [self.last_block_hash]
+                "chain_getHeader", [block_hash]
             )
 
             if block_header["result"] is None:
                 raise SubstrateRequestException(
-                    f'Block not found for "{self.last_block_hash}"'
+                    f'Block not found for "{block_hash}"'
                 )
             parent_block_hash: str = block_header["result"]["parentHash"]
 
@@ -1012,7 +1012,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 parent_block_hash
                 == "0x0000000000000000000000000000000000000000000000000000000000000000"
             ):
-                runtime_block_hash = self.last_block_hash
+                runtime_block_hash = block_hash
             else:
                 runtime_block_hash = parent_block_hash
 

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -2548,7 +2548,6 @@ class AsyncSubstrateInterface(SubstrateMixin):
             params = {}
 
         try:
-            self.registry = PortableRegistry.from_metadata_v15(self.metadata_v15)
             metadata_v15_value = self.metadata_v15.value()
 
             apis = {entry["name"]: entry for entry in metadata_v15_value["apis"]}

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -706,8 +706,6 @@ class AsyncSubstrateInterface(SubstrateMixin):
         self.runtime_config = RuntimeConfigurationObject(
             ss58_format=self.ss58_format, implements_scale_info=True
         )
-        self._metadata_cache = {}
-        self._metadata_v15_cache = {}
         self._old_metadata_v15 = None
         self._nonces = {}
         self.metadata_version_hex = "0x0f000000"  # v15
@@ -939,7 +937,6 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
         self.runtime_version = runtime_info.get("specVersion")
         self._metadata = metadata
-        self._metadata_cache[self.runtime_version] = self._metadata
         self.runtime_config.set_active_spec_version_id(self.runtime_version)
         self.transaction_version = runtime_info.get("transactionVersion")
         if self.implements_scaleinfo:

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -1112,12 +1112,11 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 " the AsyncSubstrateInterface class with `async with` or by calling `initialize()`"
             )
         runtime = self.runtime_cache.retrieve(block_id, block_hash)
-        if (
-            not runtime
-            or runtime.metadata is None
-        ):
-            runtime = await get_runtime(block_hash, block_id)
-            self.runtime_cache.add_item(block_id, block_hash, runtime)
+        if runtime and runtime.metadata is not None:
+            return runtime
+
+        runtime = await get_runtime(block_hash, block_id)
+        self.runtime_cache.add_item(block_id, block_hash, runtime)
         return runtime
 
     async def create_storage_key(

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -1018,12 +1018,6 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 )
             )
 
-            await self.load_runtime(
-                    runtime_info=runtime_info,
-                    metadata=metadata,
-                    metadata_v15=metadata_v15,
-                )
-
             runtime = Runtime(
                     chain=self.chain,
                     runtime_config=self.runtime_config,
@@ -1033,6 +1027,13 @@ class AsyncSubstrateInterface(SubstrateMixin):
                     runtime_info=runtime_info,
                 )
             self.runtime_cache.add_item(runtime_version=runtime_version, runtime=runtime)
+
+        await self.load_runtime(
+                runtime_info=runtime.runtime_info,
+                metadata=runtime.metadata,
+                metadata_v15=runtime.metadata_v15,
+            )
+
         return runtime
 
     async def create_storage_key(

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -1028,10 +1028,12 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 )
 
         runtime = Runtime(
-                self.chain,
-                self.runtime_config,
-                metadata,
-                self.type_registry,
+                chain=self.chain,
+                runtime_config=self.runtime_config,
+                metadata=metadata,
+                type_registry=self.type_registry,
+                metadata_v15=metadata_v15,
+                runtime_info=runtime_info,
             )
 
         self.runtime_cache.add_item(runtime_version=runtime_version, runtime=runtime)

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -992,6 +992,9 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 f"No runtime information for block '{block_hash}'"
             )
 
+        if runtime_version == self.runtime_version:
+            return
+
         runtime = self.runtime_cache.retrieve(runtime_version=runtime_version)
         if not runtime or runtime.metadata is None:
             self.last_block_hash = block_hash

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -993,10 +993,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
             )
 
         runtime = self.runtime_cache.retrieve(runtime_version=runtime_version)
-        if runtime and runtime.metadata is not None:
-            return runtime
-
-        if True: # keep indenting, this used to be a local function
+        if not runtime or runtime.metadata is None:
             self.last_block_hash = block_hash
 
             runtime_block_hash = await self.get_parent_block_hash(block_hash)
@@ -1027,16 +1024,15 @@ class AsyncSubstrateInterface(SubstrateMixin):
                     metadata_v15=metadata_v15,
                 )
 
-        runtime = Runtime(
-                chain=self.chain,
-                runtime_config=self.runtime_config,
-                metadata=metadata,
-                type_registry=self.type_registry,
-                metadata_v15=metadata_v15,
-                runtime_info=runtime_info,
-            )
-
-        self.runtime_cache.add_item(runtime_version=runtime_version, runtime=runtime)
+            runtime = Runtime(
+                    chain=self.chain,
+                    runtime_config=self.runtime_config,
+                    metadata=metadata,
+                    type_registry=self.type_registry,
+                    metadata_v15=metadata_v15,
+                    runtime_info=runtime_info,
+                )
+            self.runtime_cache.add_item(runtime_version=runtime_version, runtime=runtime)
         return runtime
 
     async def create_storage_key(

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -1003,51 +1003,23 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
             runtime_info = await self.get_block_runtime_info(runtime_block_hash)
 
-            if runtime_version in self._metadata_cache:
-                # Get metadata from cache
-                logger.debug(
-                    "Retrieved metadata for {} from memory".format(
-                        runtime_version
-                    )
-                )
-                metadata = self._metadata_cache[
+            # TODO when someone gets time, someone'd like to add this and the metadata v15 as tasks with callbacks
+            # TODO to update the caches, but someone doesn't have time now.
+            metadata = await self.get_block_metadata(
+                block_hash=runtime_block_hash, decode=True
+            )
+            logger.debug(
+                "Retrieved metadata for {} from Substrate node".format(
                     runtime_version
-                ]
-            else:
-                # TODO when I get time, I'd like to add this and the metadata v15 as tasks with callbacks
-                # TODO to update the caches, but I don't have time now.
-                metadata = await self.get_block_metadata(
-                    block_hash=runtime_block_hash, decode=True
                 )
-                logger.debug(
-                    "Retrieved metadata for {} from Substrate node".format(
-                        runtime_version
-                    )
-                )
+            )
 
-                # Update metadata cache
-                self._metadata_cache[runtime_version] = self._metadata
-
-            if runtime_version in self._metadata_v15_cache:
-                # Get metadata v15 from cache
-                logger.debug(
-                    "Retrieved metadata v15 for {} from memory".format(
-                        runtime_version
-                    )
-                )
-                metadata_v15 = self._metadata_v15_cache[
+            metadata_v15 = await self._load_registry_at_block(block_hash=runtime_block_hash)
+            logger.debug(
+                "Retrieved metadata v15 for {} from Substrate node".format(
                     runtime_version
-                ]
-            else:
-                metadata_v15 = await self._load_registry_at_block(block_hash=runtime_block_hash)
-                logger.debug(
-                    "Retrieved metadata v15 for {} from Substrate node".format(
-                        runtime_version
-                    )
                 )
-
-                # Update metadata v15 cache
-                self._metadata_v15_cache[runtime_version] = metadata_v15
+            )
 
             await self.load_runtime(
                     runtime_info=runtime_info,

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -777,7 +777,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
     async def get_storage_item(self, module: str, storage_function: str, block_hash: str = None):
         await self.init_runtime(block_hash=block_hash)
-        metadata_pallet = self._metadata.get_metadata_pallet(module)
+        metadata_pallet = self.runtime.metadata.get_metadata_pallet(module)
         storage_item = metadata_pallet.get_storage_function(storage_function)
         return storage_item
 
@@ -815,18 +815,18 @@ class AsyncSubstrateInterface(SubstrateMixin):
         metadata_option_hex_str = metadata_rpc_result["result"]
         metadata_option_bytes = bytes.fromhex(metadata_option_hex_str[2:])
         metadata = MetadataV15.decode_from_metadata_option(metadata_option_bytes)
-        self.registry = PortableRegistry.from_metadata_v15(metadata)
-        self._load_registry_type_map()
-        return metadata
+        registry = PortableRegistry.from_metadata_v15(metadata)
+        self._load_registry_type_map(registry)
+        return metadata,registry
 
     async def _wait_for_registry(self, _attempt: int = 1, _retries: int = 3) -> None:
         async def _waiter():
-            while self.registry is None:
+            while self.runtime.registry is None:
                 await asyncio.sleep(0.1)
             return
 
         try:
-            if not self.registry:
+            if not self.runtime.registry:
                 await asyncio.wait_for(_waiter(), timeout=10)
         except TimeoutError:
             # indicates that registry was never loaded
@@ -893,25 +893,22 @@ class AsyncSubstrateInterface(SubstrateMixin):
             return ss58_encode(scale_bytes, SS58_FORMAT)
         else:
             await self._wait_for_registry(_attempt, _retries)
-            obj = decode_by_type_string(type_string, self.registry, scale_bytes)
+            obj = decode_by_type_string(type_string, self.runtime.registry, scale_bytes)
         if return_scale_obj:
             return ScaleObj(obj)
         else:
             return obj
 
-    async def load_runtime(self,runtime_info=None,metadata=None,metadata_v15=None,registry=None):
+    async def load_runtime(self,runtime):
         # Update type registry
         self.reload_type_registry(use_remote_preset=False, auto_discover=True)
 
-        self.metadata_v15 = metadata_v15
-        self.registry = registry
-        self.runtime_version = runtime_info.get("specVersion")
-        self._metadata = metadata
-        self.runtime_config.set_active_spec_version_id(self.runtime_version)
-        self.transaction_version = runtime_info.get("transactionVersion")
+        self.runtime = runtime
+
+        self.runtime_config.set_active_spec_version_id(runtime.runtime_version)
         if self.implements_scaleinfo:
             logger.debug("Add PortableRegistry from metadata to type registry")
-            self.runtime_config.add_portable_registry(metadata)
+            self.runtime_config.add_portable_registry(runtime.metadata)
         # Set runtime compatibility flags
         try:
             _ = self.runtime_config.create_scale_object("sp_weights::weight_v2::Weight")
@@ -957,7 +954,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 f"No runtime information for block '{block_hash}'"
             )
 
-        if runtime_version == self.runtime_version:
+        if self.runtime and runtime_version == self.runtime.runtime_version:
             return
 
         runtime = self.runtime_cache.retrieve(runtime_version=runtime_version)
@@ -984,7 +981,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 )
             )
 
-            metadata_v15 = await self._load_registry_at_block(block_hash=runtime_block_hash)
+            metadata_v15,registry = await self._load_registry_at_block(block_hash=runtime_block_hash)
             logger.debug(
                 "Retrieved metadata v15 for {} from Substrate node".format(
                     runtime_version
@@ -998,16 +995,11 @@ class AsyncSubstrateInterface(SubstrateMixin):
                     type_registry=self.type_registry,
                     metadata_v15=metadata_v15,
                     runtime_info=runtime_info,
-                    registry=self.registry,
+                    registry=registry,
                 )
             self.runtime_cache.add_item(runtime_version=runtime_version, runtime=runtime)
 
-        await self.load_runtime(
-                runtime_info=runtime.runtime_info,
-                metadata=runtime.metadata,
-                metadata_v15=runtime.metadata_v15,
-                registry=runtime.registry,
-            )
+        await self.load_runtime(runtime)
 
         if self.ss58_format is None:
             # Check and apply runtime constants
@@ -1044,7 +1036,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
             storage_function,
             params,
             runtime_config=self.runtime_config,
-            metadata=self._metadata,
+            metadata=self.runtime.metadata,
         )
 
     async def get_metadata_storage_functions(self, block_hash=None) -> list:
@@ -1069,7 +1061,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                         self.serialize_storage_item(
                             storage_item=storage,
                             module=module,
-                            spec_version_id=self.runtime_version,
+                            spec_version_id=self.runtime.runtime_version,
                         )
                     )
 
@@ -1112,14 +1104,14 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
         error_list = []
 
-        for module_idx, module in enumerate(self._metadata.pallets):
+        for module_idx, module in enumerate(self.runtime.metadata.pallets):
             if module.errors:
                 for error in module.errors:
                     error_list.append(
                         self.serialize_module_error(
                             module=module,
                             error=error,
-                            spec_version=self.runtime_version,
+                            spec_version=self.runtime.runtime_version,
                         )
                     )
 
@@ -1140,7 +1132,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         """
         await self.init_runtime(block_hash=block_hash)
 
-        for module_idx, module in enumerate(self._metadata.pallets):
+        for module_idx, module in enumerate(self.runtime.metadata.pallets):
             if module.name == module_name and module.errors:
                 for error in module.errors:
                     if error_name == error.name:
@@ -1233,7 +1225,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                         try:
                             extrinsic_decoder = extrinsic_cls(
                                 data=ScaleBytes(extrinsic_data),
-                                metadata=self._metadata,
+                                metadata=self.runtime.metadata,
                                 runtime_config=self.runtime_config,
                             )
                             extrinsic_decoder.decode(check_remaining=True)
@@ -1761,7 +1753,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         """
         params = query_for if query_for else []
         # Search storage call in metadata
-        metadata_pallet = self._metadata.get_metadata_pallet(module)
+        metadata_pallet = self.runtime.metadata.get_metadata_pallet(module)
 
         if not metadata_pallet:
             raise SubstrateRequestException(f'Pallet "{module}" not found')
@@ -1797,7 +1789,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 storage_item.value["name"],
                 params,
                 runtime_config=self.runtime_config,
-                metadata=self._metadata,
+                metadata=self.runtime.metadata,
             )
         method = "state_getStorageAt"
         return Preprocessed(
@@ -2048,7 +2040,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         await self.init_runtime(block_hash=block_hash)
 
         call = self.runtime_config.create_scale_object(
-            type_string="Call", metadata=self._metadata
+            type_string="Call", metadata=self.runtime.metadata
         )
 
         call.encode(
@@ -2227,12 +2219,12 @@ class AsyncSubstrateInterface(SubstrateMixin):
         )
 
         # Process signed extensions in metadata
-        if "signed_extensions" in self._metadata[1][1]["extrinsic"]:
+        if "signed_extensions" in self.runtime.metadata[1][1]["extrinsic"]:
             # Base signature payload
             signature_payload.type_mapping = [["call", "CallBytes"]]
 
             # Add signed extensions to payload
-            signed_extensions = self._metadata.get_signed_extensions()
+            signed_extensions = self.runtime.metadata.get_signed_extensions()
 
             if "CheckMortality" in signed_extensions:
                 signature_payload.type_mapping.append(
@@ -2321,10 +2313,10 @@ class AsyncSubstrateInterface(SubstrateMixin):
             "era": era,
             "nonce": nonce,
             "tip": tip,
-            "spec_version": self.runtime_version,
+            "spec_version": self.runtime.runtime_version,
             "genesis_hash": genesis_hash,
             "block_hash": block_hash,
-            "transaction_version": self.transaction_version,
+            "transaction_version": self.runtime.transaction_version,
             "asset_id": {"tip": tip, "asset_id": tip_asset_id},
             "metadata_hash": None,
             "mode": "Disabled",
@@ -2373,9 +2365,9 @@ class AsyncSubstrateInterface(SubstrateMixin):
             raise TypeError("'call' must be of type Call")
 
         # Check if extrinsic version is supported
-        if self._metadata[1][1]["extrinsic"]["version"] != 4:  # type: ignore
+        if self.runtime.metadata[1][1]["extrinsic"]["version"] != 4:  # type: ignore
             raise NotImplementedError(
-                f"Extrinsic version {self._metadata[1][1]['extrinsic']['version']} not supported"  # type: ignore
+                f"Extrinsic version {self.runtime.metadata[1][1]['extrinsic']['version']} not supported"  # type: ignore
             )
 
         # Retrieve nonce
@@ -2417,7 +2409,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
         # Create extrinsic
         extrinsic = self.runtime_config.create_scale_object(
-            type_string="Extrinsic", metadata=self._metadata
+            type_string="Extrinsic", metadata=self.runtime.metadata
         )
 
         value = {
@@ -2533,7 +2525,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
             params = {}
 
         try:
-            metadata_v15_value = self.metadata_v15.value()
+            metadata_v15_value = self.runtime.metadata_v15.value()
 
             apis = {entry["name"]: entry for entry in metadata_v15_value["apis"]}
             api_entry = apis[api]
@@ -2641,7 +2633,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         """
         await self.init_runtime(block_hash=block_hash)
 
-        for module in self._metadata.pallets:
+        for module in self.runtime.metadata.pallets:
             if module_name == module.name and module.constants:
                 for constant in module.constants:
                     if constant_name == constant.value["name"]:
@@ -2790,7 +2782,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 "metadata_index": idx,
                 "module_id": module.get_identifier(),
                 "name": module.name,
-                "spec_version": self.runtime_version,
+                "spec_version": self.runtime.runtime_version,
                 "count_call_functions": len(module.calls or []),
                 "count_storage_functions": len(module.storage or []),
                 "count_events": len(module.events or []),
@@ -2907,7 +2899,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
             self.last_block_hash = block_hash
         await self.init_runtime(block_hash=block_hash)
 
-        metadata_pallet = self._metadata.get_metadata_pallet(module)
+        metadata_pallet = self.runtime.metadata.get_metadata_pallet(module)
         if not metadata_pallet:
             raise ValueError(f'Pallet "{module}" not found')
         storage_item = metadata_pallet.get_storage_function(storage_function)
@@ -2935,7 +2927,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
             storage_item.value["name"],
             params,
             runtime_config=self.runtime_config,
-            metadata=self._metadata,
+            metadata=self.runtime.metadata,
         )
         prefix = storage_key.to_hex()
 

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -925,7 +925,18 @@ class AsyncSubstrateInterface(SubstrateMixin):
         )
         await self.load_runtime(runtime_info=runtime_info, metadata=metadata)
 
+        # Check and apply runtime constants
+        ss58_prefix_constant = await self.get_constant(
+            "System", "SS58Prefix"
+        )
+
+        if ss58_prefix_constant:
+            self.ss58_format = ss58_prefix_constant
+
     async def load_runtime(self,runtime_info=None,metadata=None,metadata_v15=None):
+        # Update type registry
+        self.reload_type_registry(use_remote_preset=False, auto_discover=True)
+
         self.runtime_version = runtime_info.get("specVersion")
         self._metadata = metadata
         self._metadata_cache[self.runtime_version] = self._metadata
@@ -1037,17 +1048,6 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
                 # Update metadata v15 cache
                 self._metadata_v15_cache[runtime_version] = metadata_v15
-
-            # Update type registry
-            self.reload_type_registry(use_remote_preset=False, auto_discover=True)
-
-            # Check and apply runtime constants
-            ss58_prefix_constant = await self.get_constant(
-                "System", "SS58Prefix", block_hash=block_hash
-            )
-
-            if ss58_prefix_constant:
-                self.ss58_format = ss58_prefix_constant
 
             await self.load_runtime(
                     runtime_info=runtime_info,

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -900,10 +900,10 @@ class AsyncSubstrateInterface(SubstrateMixin):
             return obj
 
     async def load_runtime(self,runtime):
+        self.runtime = runtime
+
         # Update type registry
         self.reload_type_registry(use_remote_preset=False, auto_discover=True)
-
-        self.runtime = runtime
 
         self.runtime_config.set_active_spec_version_id(runtime.runtime_version)
         if self.implements_scaleinfo:

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -2078,6 +2078,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         else:
             raise SubstrateRequestException(result[payload_id][0])
 
+    @a.lru_cache(maxsize=512) # block_id->block_hash does not change
     async def get_block_hash(self, block_id: int) -> str:
         return (await self.rpc_request("chain_getBlockHash", [block_id]))["result"]
 

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -996,7 +996,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
             return
 
         runtime = self.runtime_cache.retrieve(runtime_version=runtime_version)
-        if not runtime or runtime.metadata is None:
+        if not runtime:
             self.last_block_hash = block_hash
 
             runtime_block_hash = await self.get_parent_block_hash(block_hash)
@@ -1008,6 +1008,11 @@ class AsyncSubstrateInterface(SubstrateMixin):
             metadata = await self.get_block_metadata(
                 block_hash=runtime_block_hash, decode=True
             )
+            if metadata is None:
+                # does this ever happen?
+                raise SubstrateRequestException(
+                    f"No metadata for block '{runtime_block_hash}'"
+                )
             logger.debug(
                 "Retrieved metadata for {} from Substrate node".format(
                     runtime_version

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -985,7 +985,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         if runtime and runtime.metadata is not None:
             return runtime
 
-        async def get_runtime(block_hash,runtime_version) -> Runtime:
+        if True: # keep indenting, this used to be a local function
             self.last_block_hash = block_hash
 
             runtime_block_hash = await self.get_parent_block_hash(block_hash)
@@ -1055,20 +1055,13 @@ class AsyncSubstrateInterface(SubstrateMixin):
                     metadata_v15=metadata_v15,
                 )
 
-            return Runtime(
+        runtime = Runtime(
                 self.chain,
                 self.runtime_config,
                 metadata,
                 self.type_registry,
             )
 
-        if not self.metadata_v15:
-            raise SubstrateRequestException(
-                "Metadata V15 was not loaded. This usually indicates that you did not correctly initialize"
-                " the AsyncSubstrateInterface class with `async with` or by calling `initialize()`"
-            )
-
-        runtime = await get_runtime(block_hash,runtime_version)
         self.runtime_cache.add_item(runtime_version=runtime_version, runtime=runtime)
         return runtime
 

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -1034,8 +1034,6 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 metadata_v15=runtime.metadata_v15,
             )
 
-        return runtime
-
     async def create_storage_key(
         self,
         pallet: str,
@@ -2199,9 +2197,9 @@ class AsyncSubstrateInterface(SubstrateMixin):
         Returns:
              The created Scale Type object
         """
-        runtime = await self.init_runtime(block_hash=block_hash)
+        await self.init_runtime(block_hash=block_hash)
         if "metadata" not in kwargs:
-            kwargs["metadata"] = runtime.metadata
+            kwargs["metadata"] = self.runtime.metadata
 
         return runtime.runtime_config.create_scale_object(
             type_string, data=data, **kwargs
@@ -3199,9 +3197,9 @@ class AsyncSubstrateInterface(SubstrateMixin):
         Returns:
             list of call functions
         """
-        runtime = await self.init_runtime(block_hash=block_hash)
+        await self.init_runtime(block_hash=block_hash)
 
-        for pallet in runtime.metadata.pallets:
+        for pallet in self.runtime.metadata.pallets:
             if pallet.name == module_name and pallet.calls:
                 for call in pallet.calls:
                     if call.name == call_function_name:

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -975,7 +975,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         if not block_hash:
             block_hash = await self.get_chain_head()
 
-        runtime = self.runtime_cache.retrieve(block_id, block_hash)
+        runtime = self.runtime_cache.retrieve(block_hash=block_hash)
         if runtime and runtime.metadata is not None:
             return runtime
 
@@ -1115,7 +1115,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
             )
 
         runtime = await get_runtime(block_hash)
-        self.runtime_cache.add_item(block_id, block_hash, runtime)
+        self.runtime_cache.add_item(block_hash=block_hash, runtime=runtime)
         return runtime
 
     async def create_storage_key(

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -986,33 +986,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
             return runtime
 
         async def get_runtime(block_hash,runtime_version) -> Runtime:
-            # Check if runtime state already set to current block
-            if (
-                block_hash and block_hash == self.last_block_hash
-            ) and all(
-                x is not None
-                for x in [self._metadata, self._old_metadata_v15, self.metadata_v15]
-            ):
-                return Runtime(
-                    self.chain,
-                    self.runtime_config,
-                    self._metadata,
-                    self.type_registry,
-                )
-
             self.last_block_hash = block_hash
-
-            # Check if runtime state already set to current block
-            if runtime_version == self.runtime_version and all(
-                x is not None
-                for x in [self._metadata, self._old_metadata_v15, self.metadata_v15]
-            ):
-                return Runtime(
-                    self.chain,
-                    self.runtime_config,
-                    self._metadata,
-                    self.type_registry,
-                )
 
             runtime_block_hash = await self.get_parent_block_hash(block_hash)
 

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -969,6 +969,10 @@ class AsyncSubstrateInterface(SubstrateMixin):
         if block_id and block_hash:
             raise ValueError("Cannot provide block_hash and block_id at the same time")
 
+        runtime = self.runtime_cache.retrieve(block_id, block_hash)
+        if runtime and runtime.metadata is not None:
+            return runtime
+
         async def get_runtime(block_hash, block_id) -> Runtime:
             # Check if runtime state already set to current block
             if (
@@ -1111,9 +1115,6 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 "Metadata V15 was not loaded. This usually indicates that you did not correctly initialize"
                 " the AsyncSubstrateInterface class with `async with` or by calling `initialize()`"
             )
-        runtime = self.runtime_cache.retrieve(block_id, block_hash)
-        if runtime and runtime.metadata is not None:
-            return runtime
 
         runtime = await get_runtime(block_hash, block_id)
         self.runtime_cache.add_item(block_id, block_hash, runtime)

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -773,10 +773,12 @@ class SubstrateInterface(SubstrateMixin):
                 )
 
         runtime = Runtime(
-                self.chain,
-                self.runtime_config,
-                metadata,
-                self.type_registry,
+                chain=self.chain,
+                runtime_config=self.runtime_config,
+                metadata=metadata,
+                type_registry=self.type_registry,
+                metadata_v15=metadata_v15,
+                runtime_info=runtime_info,
             )
         self.runtime_cache.add_item(runtime_version=runtime_version, runtime=runtime)
         return runtime

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -720,7 +720,7 @@ class SubstrateInterface(SubstrateMixin):
         if not block_hash:
             block_hash = self.get_chain_head()
 
-        runtime = self.runtime_cache.retrieve(block_id, block_hash)
+        runtime = self.runtime_cache.retrieve(block_hash=block_hash)
         if runtime and runtime.metadata is not None:
             return runtime
 
@@ -846,7 +846,7 @@ class SubstrateInterface(SubstrateMixin):
             )
 
         runtime = get_runtime(block_hash)
-        self.runtime_cache.add_item(block_id, block_hash, runtime)
+        self.runtime_cache.add_item(block_hash=block_hash, runtime=runtime)
         return runtime
 
     def create_storage_key(

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -779,8 +779,6 @@ class SubstrateInterface(SubstrateMixin):
                 metadata_v15=runtime.metadata_v15,
             )
 
-        return runtime
-
     def create_storage_key(
         self,
         pallet: str,
@@ -1920,10 +1918,10 @@ class SubstrateInterface(SubstrateMixin):
         Returns:
              The created Scale Type object
         """
-        runtime = self.init_runtime(block_hash=block_hash)
+        self.init_runtime(block_hash=block_hash)
 
         if "metadata" not in kwargs:
-            kwargs["metadata"] = runtime.metadata
+            kwargs["metadata"] = self.runtime.metadata
 
         return runtime.runtime_config.create_scale_object(
             type_string, data=data, **kwargs
@@ -2893,9 +2891,9 @@ class SubstrateInterface(SubstrateMixin):
         Returns:
             list of call functions
         """
-        runtime = self.init_runtime(block_hash=block_hash)
+        self.init_runtime(block_hash=block_hash)
 
-        for pallet in runtime.metadata.pallets:
+        for pallet in self.runtime.metadata.pallets:
             if pallet.name == module_name and pallet.calls:
                 for call in pallet.calls:
                     if call.name == call_function_name:

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -743,11 +743,11 @@ class SubstrateInterface(SubstrateMixin):
 
             # In fact calls and storage functions are decoded against runtime of previous block, therefore retrieve
             # metadata and apply type registry of runtime of parent block
-            block_header = self.rpc_request("chain_getHeader", [self.last_block_hash])
+            block_header = self.rpc_request("chain_getHeader", [block_hash])
 
             if block_header["result"] is None:
                 raise SubstrateRequestException(
-                    f'Block not found for "{self.last_block_hash}"'
+                    f'Block not found for "{block_hash}"'
                 )
             parent_block_hash: str = block_header["result"]["parentHash"]
 
@@ -755,7 +755,7 @@ class SubstrateInterface(SubstrateMixin):
                 parent_block_hash
                 == "0x0000000000000000000000000000000000000000000000000000000000000000"
             ):
-                runtime_block_hash = self.last_block_hash
+                runtime_block_hash = block_hash
             else:
                 runtime_block_hash = parent_block_hash
 

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -714,6 +714,10 @@ class SubstrateInterface(SubstrateMixin):
         if block_id and block_hash:
             raise ValueError("Cannot provide block_hash and block_id at the same time")
 
+        runtime = self.runtime_cache.retrieve(block_id, block_hash)
+        if runtime and runtime.metadata is not None:
+            return runtime
+
         def get_runtime(block_hash, block_id) -> Runtime:
             # Check if runtime state already set to current block
             if (
@@ -842,10 +846,6 @@ class SubstrateInterface(SubstrateMixin):
                 metadata,
                 self.type_registry,
             )
-
-        runtime = self.runtime_cache.retrieve(block_id, block_hash)
-        if runtime and runtime.metadata is not None:
-            return runtime
 
         runtime = get_runtime(block_hash, block_id)
         self.runtime_cache.add_item(block_id, block_hash, runtime)

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -671,14 +671,17 @@ class SubstrateInterface(SubstrateMixin):
             metadata = self.get_block_metadata(),
         )
 
-    def load_runtime(self,runtime_info=None,metadata=None):
+    def load_runtime(self,runtime_info=None,metadata=None,metadata_v15=None):
         self.runtime_version = runtime_info.get("specVersion")
         self._metadata = metadata
         self._metadata_cache[self.runtime_version] = self._metadata
         self.runtime_config.set_active_spec_version_id(self.runtime_version)
         self.transaction_version = runtime_info.get("transactionVersion")
         if self.implements_scaleinfo:
+            logger.debug("Add PortableRegistry from metadata to type registry")
             self.runtime_config.add_portable_registry(metadata)
+        if metadata_v15 is not None:
+            self._old_metadata_v15 = metadata_v15
         # Set runtime compatibility flags
         try:
             _ = self.runtime_config.create_scale_object("sp_weights::weight_v2::Weight")
@@ -770,66 +773,52 @@ class SubstrateInterface(SubstrateMixin):
                     self.type_registry,
                 )
 
-            self.runtime_version = runtime_info.get("specVersion")
-            self.transaction_version = runtime_info.get("transactionVersion")
+            runtime_version = runtime_info.get("specVersion")
 
-            if not self._metadata:
-                if self.runtime_version in self._metadata_cache:
-                    # Get metadata from cache
-                    logger.debug(
-                        "Retrieved metadata for {} from memory".format(
-                            self.runtime_version
-                        )
+            if runtime_version in self._metadata_cache:
+                # Get metadata from cache
+                logger.debug(
+                    "Retrieved metadata for {} from memory".format(
+                        runtime_version
                     )
-                    metadata = self._metadata = self._metadata_cache[
-                        self.runtime_version
-                    ]
-                else:
-                    metadata = self._metadata = self.get_block_metadata(
-                        block_hash=runtime_block_hash, decode=True
-                    )
-                    logger.debug(
-                        "Retrieved metadata for {} from Substrate node".format(
-                            self.runtime_version
-                        )
-                    )
-
-                    # Update metadata cache
-                    self._metadata_cache[self.runtime_version] = self._metadata
+                )
+                metadata = self._metadata_cache[
+                    runtime_version
+                ]
             else:
-                metadata = self._metadata
+                metadata = self.get_block_metadata(
+                    block_hash=runtime_block_hash, decode=True
+                )
+                logger.debug(
+                    "Retrieved metadata for {} from Substrate node".format(
+                        runtime_version
+                    )
+                )
 
-            if self.runtime_version in self._metadata_v15_cache:
+            if runtime_version in self._metadata_v15_cache:
                 # Get metadata v15 from cache
                 logger.debug(
                     "Retrieved metadata v15 for {} from memory".format(
-                        self.runtime_version
+                        runtime_version
                     )
                 )
-                metadata_v15 = self._old_metadata_v15 = self._metadata_v15_cache[
-                    self.runtime_version
+                metadata_v15 = self._metadata_v15_cache[
+                    runtime_version
                 ]
             else:
-                metadata_v15 = self._old_metadata_v15 = self._load_registry_at_block(
+                metadata_v15 = self._load_registry_at_block(
                     block_hash=runtime_block_hash
                 )
                 logger.debug(
                     "Retrieved metadata v15 for {} from Substrate node".format(
-                        self.runtime_version
+                        runtime_version
                     )
                 )
                 # Update metadata v15 cache
-                self._metadata_v15_cache[self.runtime_version] = metadata_v15
+                self._metadata_v15_cache[runtime_version] = metadata_v15
 
             # Update type registry
             self.reload_type_registry(use_remote_preset=False, auto_discover=True)
-
-            if self.implements_scaleinfo:
-                logger.debug("Add PortableRegistry from metadata to type registry")
-                self.runtime_config.add_portable_registry(metadata)
-
-            # Set active runtime version
-            self.runtime_config.set_active_spec_version_id(self.runtime_version)
 
             # Check and apply runtime constants
             ss58_prefix_constant = self.get_constant(
@@ -839,18 +828,12 @@ class SubstrateInterface(SubstrateMixin):
             if ss58_prefix_constant:
                 self.ss58_format = ss58_prefix_constant
 
-            # Set runtime compatibility flags
-            try:
-                _ = self.runtime_config.create_scale_object(
-                    "sp_weights::weight_v2::Weight"
+            self.load_runtime(
+                    runtime_info=runtime_info,
+                    metadata=metadata,
+                    metadata_v15=metadata_v15,
                 )
-                self.config["is_weight_v2"] = True
-                self.runtime_config.update_type_registry_types(
-                    {"Weight": "sp_weights::weight_v2::Weight"}
-                )
-            except NotImplementedError:
-                self.config["is_weight_v2"] = False
-                self.runtime_config.update_type_registry_types({"Weight": "WeightV1"})
+
             return Runtime(
                 self.chain,
                 self.runtime_config,

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -844,12 +844,11 @@ class SubstrateInterface(SubstrateMixin):
             )
 
         runtime = self.runtime_cache.retrieve(block_id, block_hash)
-        if (
-            not runtime
-            or runtime.metadata is None
-        ):
-            runtime = get_runtime(block_hash, block_id)
-            self.runtime_cache.add_item(block_id, block_hash, runtime)
+        if runtime and runtime.metadata is not None:
+            return runtime
+
+        runtime = get_runtime(block_hash, block_id)
+        self.runtime_cache.add_item(block_id, block_hash, runtime)
         return runtime
 
     def create_storage_key(

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -737,6 +737,9 @@ class SubstrateInterface(SubstrateMixin):
                 f"No runtime information for block '{block_hash}'"
             )
 
+        if runtime_version == self.runtime_version:
+            return
+
         runtime = self.runtime_cache.retrieve(runtime_version=runtime_version)
         if not runtime or runtime.metadata is None:
             self.last_block_hash = block_hash

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -741,7 +741,7 @@ class SubstrateInterface(SubstrateMixin):
             return
 
         runtime = self.runtime_cache.retrieve(runtime_version=runtime_version)
-        if not runtime or runtime.metadata is None:
+        if not runtime:
             self.last_block_hash = block_hash
 
             runtime_block_hash = self.get_parent_block_hash(block_hash)
@@ -751,6 +751,11 @@ class SubstrateInterface(SubstrateMixin):
             metadata = self.get_block_metadata(
                 block_hash=runtime_block_hash, decode=True
             )
+            if metadata is None:
+                # does this ever happen?
+                raise SubstrateRequestException(
+                    f"No metadata for block '{runtime_block_hash}'"
+                )
             logger.debug(
                 "Retrieved metadata for {} from Substrate node".format(
                     runtime_version

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -763,12 +763,6 @@ class SubstrateInterface(SubstrateMixin):
                 )
             )
 
-            self.load_runtime(
-                    runtime_info=runtime_info,
-                    metadata=metadata,
-                    metadata_v15=metadata_v15,
-                )
-
             runtime = Runtime(
                     chain=self.chain,
                     runtime_config=self.runtime_config,
@@ -778,6 +772,13 @@ class SubstrateInterface(SubstrateMixin):
                     runtime_info=runtime_info,
                 )
             self.runtime_cache.add_item(runtime_version=runtime_version, runtime=runtime)
+
+        self.load_runtime(
+                runtime_info=runtime.runtime_info,
+                metadata=runtime.metadata,
+                metadata_v15=runtime.metadata_v15,
+            )
+
         return runtime
 
     def create_storage_key(

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -2260,7 +2260,6 @@ class SubstrateInterface(SubstrateMixin):
             params = {}
 
         try:
-            self.registry = PortableRegistry.from_metadata_v15(self.metadata_v15)
             metadata_v15_value = self.metadata_v15.value()
 
             apis = {entry["name"]: entry for entry in metadata_v15_value["apis"]}

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -743,21 +743,7 @@ class SubstrateInterface(SubstrateMixin):
 
             # In fact calls and storage functions are decoded against runtime of previous block, therefore retrieve
             # metadata and apply type registry of runtime of parent block
-            block_header = self.rpc_request("chain_getHeader", [block_hash])
-
-            if block_header["result"] is None:
-                raise SubstrateRequestException(
-                    f'Block not found for "{block_hash}"'
-                )
-            parent_block_hash: str = block_header["result"]["parentHash"]
-
-            if (
-                parent_block_hash
-                == "0x0000000000000000000000000000000000000000000000000000000000000000"
-            ):
-                runtime_block_hash = block_hash
-            else:
-                runtime_block_hash = parent_block_hash
+            runtime_block_hash = self.get_parent_block_hash(block_hash)
 
             runtime_info = self.get_block_runtime_version(block_hash=runtime_block_hash)
 
@@ -1497,6 +1483,20 @@ class SubstrateInterface(SubstrateMixin):
             for item in list(storage_obj):
                 events.append(convert_event_data(item))
         return events
+
+    def get_parent_block_hash(self,block_hash):
+        block_header = self.rpc_request("chain_getHeader", [block_hash])
+
+        if block_header["result"] is None:
+            raise SubstrateRequestException(
+                f'Block not found for "{block_hash}"'
+            )
+        parent_block_hash: str = block_header["result"]["parentHash"]
+
+        if int(parent_block_hash,16) == 0:
+            # "0x0000000000000000000000000000000000000000000000000000000000000000"
+            return block_hash
+        return parent_block_hash
 
     def get_block_runtime_version(self, block_hash: str) -> dict:
         """

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -512,8 +512,6 @@ class SubstrateInterface(SubstrateMixin):
         self.runtime_config = RuntimeConfigurationObject(
             ss58_format=self.ss58_format, implements_scale_info=True
         )
-        self._metadata_cache = {}
-        self._metadata_v15_cache = {}
         self._old_metadata_v15 = None
         self.metadata_version_hex = "0x0f000000"  # v15
         self.reload_type_registry()
@@ -684,7 +682,6 @@ class SubstrateInterface(SubstrateMixin):
 
         self.runtime_version = runtime_info.get("specVersion")
         self._metadata = metadata
-        self._metadata_cache[self.runtime_version] = self._metadata
         self.runtime_config.set_active_spec_version_id(self.runtime_version)
         self.transaction_version = runtime_info.get("transactionVersion")
         if self.implements_scaleinfo:

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -670,7 +670,18 @@ class SubstrateInterface(SubstrateMixin):
             metadata = self.get_block_metadata(),
         )
 
+        # Check and apply runtime constants
+        ss58_prefix_constant = self.get_constant(
+            "System", "SS58Prefix"
+        )
+
+        if ss58_prefix_constant:
+            self.ss58_format = ss58_prefix_constant
+
     def load_runtime(self,runtime_info=None,metadata=None,metadata_v15=None):
+        # Update type registry
+        self.reload_type_registry(use_remote_preset=False, auto_discover=True)
+
         self.runtime_version = runtime_info.get("specVersion")
         self._metadata = metadata
         self._metadata_cache[self.runtime_version] = self._metadata
@@ -778,17 +789,6 @@ class SubstrateInterface(SubstrateMixin):
                 )
                 # Update metadata v15 cache
                 self._metadata_v15_cache[runtime_version] = metadata_v15
-
-            # Update type registry
-            self.reload_type_registry(use_remote_preset=False, auto_discover=True)
-
-            # Check and apply runtime constants
-            ss58_prefix_constant = self.get_constant(
-                "System", "SS58Prefix", block_hash=block_hash
-            )
-
-            if ss58_prefix_constant:
-                self.ss58_format = ss58_prefix_constant
 
             self.load_runtime(
                     runtime_info=runtime_info,

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -604,19 +604,11 @@ class SubstrateInterface(SubstrateMixin):
 
     def load_registry(self):
         # This needs to happen before init_runtime
-        metadata_rpc_result = self.rpc_request(
-            "state_call",
-            ["Metadata_metadata_at_version", self.metadata_version_hex],
-        )
-        metadata_option_hex_str = metadata_rpc_result["result"]
-        metadata_option_bytes = bytes.fromhex(metadata_option_hex_str[2:])
-        self.metadata_v15 = MetadataV15.decode_from_metadata_option(
-            metadata_option_bytes
-        )
+        self.metadata_v15 = self._load_registry_at_block(None)
         self.registry = PortableRegistry.from_metadata_v15(self.metadata_v15)
         self._load_registry_type_map()
 
-    def _load_registry_at_block(self, block_hash: str) -> MetadataV15:
+    def _load_registry_at_block(self, block_hash: Optional[str]) -> MetadataV15:
         # Should be called for any block that fails decoding.
         # Possibly the metadata was different.
         metadata_rpc_result = self.rpc_request(
@@ -626,9 +618,8 @@ class SubstrateInterface(SubstrateMixin):
         )
         metadata_option_hex_str = metadata_rpc_result["result"]
         metadata_option_bytes = bytes.fromhex(metadata_option_hex_str[2:])
-        old_metadata = MetadataV15.decode_from_metadata_option(metadata_option_bytes)
-
-        return old_metadata
+        metadata = MetadataV15.decode_from_metadata_option(metadata_option_bytes)
+        return metadata
 
     def decode_scale(
         self,

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -738,10 +738,7 @@ class SubstrateInterface(SubstrateMixin):
             )
 
         runtime = self.runtime_cache.retrieve(runtime_version=runtime_version)
-        if runtime and runtime.metadata is not None:
-            return runtime
-
-        if True: # keep indenting, this used to be a local function
+        if not runtime or runtime.metadata is None:
             self.last_block_hash = block_hash
 
             runtime_block_hash = self.get_parent_block_hash(block_hash)
@@ -772,15 +769,15 @@ class SubstrateInterface(SubstrateMixin):
                     metadata_v15=metadata_v15,
                 )
 
-        runtime = Runtime(
-                chain=self.chain,
-                runtime_config=self.runtime_config,
-                metadata=metadata,
-                type_registry=self.type_registry,
-                metadata_v15=metadata_v15,
-                runtime_info=runtime_info,
-            )
-        self.runtime_cache.add_item(runtime_version=runtime_version, runtime=runtime)
+            runtime = Runtime(
+                    chain=self.chain,
+                    runtime_config=self.runtime_config,
+                    metadata=metadata,
+                    type_registry=self.type_registry,
+                    metadata_v15=metadata_v15,
+                    runtime_info=runtime_info,
+                )
+            self.runtime_cache.add_item(runtime_version=runtime_version, runtime=runtime)
         return runtime
 
     def create_storage_key(

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -645,10 +645,10 @@ class SubstrateInterface(SubstrateMixin):
             return obj
 
     def load_runtime(self,runtime):
+        self.runtime = runtime
+
         # Update type registry
         self.reload_type_registry(use_remote_preset=False, auto_discover=True)
-
-        self.runtime = runtime
 
         self.runtime_config.set_active_spec_version_id(runtime.runtime_version)
         if self.implements_scaleinfo:

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -1794,6 +1794,7 @@ class SubstrateInterface(SubstrateMixin):
         else:
             raise SubstrateRequestException(result[payload_id][0])
 
+    @lru_cache(maxsize=512) # block_id->block_hash does not change
     def get_block_hash(self, block_id: int) -> str:
         return self.rpc_request("chain_getBlockHash", [block_id])["result"]
 

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -748,47 +748,23 @@ class SubstrateInterface(SubstrateMixin):
 
             runtime_info = self.get_block_runtime_info(runtime_block_hash)
 
-            if runtime_version in self._metadata_cache:
-                # Get metadata from cache
-                logger.debug(
-                    "Retrieved metadata for {} from memory".format(
-                        runtime_version
-                    )
-                )
-                metadata = self._metadata_cache[
+            metadata = self.get_block_metadata(
+                block_hash=runtime_block_hash, decode=True
+            )
+            logger.debug(
+                "Retrieved metadata for {} from Substrate node".format(
                     runtime_version
-                ]
-            else:
-                metadata = self.get_block_metadata(
-                    block_hash=runtime_block_hash, decode=True
                 )
-                logger.debug(
-                    "Retrieved metadata for {} from Substrate node".format(
-                        runtime_version
-                    )
-                )
+            )
 
-            if runtime_version in self._metadata_v15_cache:
-                # Get metadata v15 from cache
-                logger.debug(
-                    "Retrieved metadata v15 for {} from memory".format(
-                        runtime_version
-                    )
-                )
-                metadata_v15 = self._metadata_v15_cache[
+            metadata_v15 = self._load_registry_at_block(
+                block_hash=runtime_block_hash
+            )
+            logger.debug(
+                "Retrieved metadata v15 for {} from Substrate node".format(
                     runtime_version
-                ]
-            else:
-                metadata_v15 = self._load_registry_at_block(
-                    block_hash=runtime_block_hash
                 )
-                logger.debug(
-                    "Retrieved metadata v15 for {} from Substrate node".format(
-                        runtime_version
-                    )
-                )
-                # Update metadata v15 cache
-                self._metadata_v15_cache[runtime_version] = metadata_v15
+            )
 
             self.load_runtime(
                     runtime_info=runtime_info,

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -535,7 +535,7 @@ class SubstrateInterface(SubstrateMixin):
             if not self._chain:
                 chain = self.rpc_request("system_chain", [])
                 self._chain = chain.get("result")
-            self._first_initialize_runtime()
+            self.init_runtime()
         self.initialized = True
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -643,26 +643,6 @@ class SubstrateInterface(SubstrateMixin):
             return ScaleObj(obj)
         else:
             return obj
-
-    def _first_initialize_runtime(self):
-        """
-        TODO docstring
-        """
-        metadata_v15 = self._load_registry_at_block(None)
-        self.load_runtime(
-            runtime_info = self.get_block_runtime_info(None),
-            metadata = self.get_block_metadata(),
-            metadata_v15 = metadata_v15,
-            registry = self.registry,
-        )
-
-        # Check and apply runtime constants
-        ss58_prefix_constant = self.get_constant(
-            "System", "SS58Prefix"
-        )
-
-        if ss58_prefix_constant:
-            self.ss58_format = ss58_prefix_constant
 
     def load_runtime(self,runtime_info=None,metadata=None,metadata_v15=None,registry=None):
         # Update type registry
@@ -773,6 +753,15 @@ class SubstrateInterface(SubstrateMixin):
                 metadata_v15=runtime.metadata_v15,
                 registry=runtime.registry,
             )
+
+        if self.ss58_format is None:
+            # Check and apply runtime constants
+            ss58_prefix_constant = self.get_constant(
+                "System", "SS58Prefix", block_hash=block_hash
+            )
+
+            if ss58_prefix_constant:
+                self.ss58_format = ss58_prefix_constant
 
     def create_storage_key(
         self,

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -711,6 +711,9 @@ class SubstrateInterface(SubstrateMixin):
             Runtime object
         """
 
+        if block_id and block_hash:
+            raise ValueError("Cannot provide block_hash and block_id at the same time")
+
         def get_runtime(block_hash, block_id) -> Runtime:
             # Check if runtime state already set to current block
             if (
@@ -840,11 +843,9 @@ class SubstrateInterface(SubstrateMixin):
                 self.type_registry,
             )
 
-        if block_id and block_hash:
-            raise ValueError("Cannot provide block_hash and block_id at the same time")
-
+        runtime = self.runtime_cache.retrieve(block_id, block_hash)
         if (
-            not (runtime := self.runtime_cache.retrieve(block_id, block_hash))
+            not runtime
             or runtime.metadata is None
         ):
             runtime = get_runtime(block_hash, block_id)

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -666,11 +666,15 @@ class SubstrateInterface(SubstrateMixin):
         """
         TODO docstring
         """
-        runtime_info = self.get_block_runtime_version(None)
-        metadata = self.get_block_metadata()
+        self.load_runtime(
+            runtime_info = self.get_block_runtime_version(None),
+            metadata = self.get_block_metadata(),
+        )
+
+    def load_runtime(self,runtime_info=None,metadata=None):
+        self.runtime_version = runtime_info.get("specVersion")
         self._metadata = metadata
         self._metadata_cache[self.runtime_version] = self._metadata
-        self.runtime_version = runtime_info.get("specVersion")
         self.runtime_config.set_active_spec_version_id(self.runtime_version)
         self.transaction_version = runtime_info.get("transactionVersion")
         if self.implements_scaleinfo:

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -731,33 +731,7 @@ class SubstrateInterface(SubstrateMixin):
             return runtime
 
         def get_runtime(block_hash,runtime_version) -> Runtime:
-            # Check if runtime state already set to current block
-            if (
-                block_hash and block_hash == self.last_block_hash
-            ) and all(
-                x is not None
-                for x in [self._metadata, self._old_metadata_v15, self.metadata_v15]
-            ):
-                return Runtime(
-                    self.chain,
-                    self.runtime_config,
-                    self._metadata,
-                    self.type_registry,
-                )
-
             self.last_block_hash = block_hash
-
-            # Check if runtime state already set to current block
-            if runtime_version == self.runtime_version and all(
-                x is not None
-                for x in [self._metadata, self._old_metadata_v15, self.metadata_v15]
-            ):
-                return Runtime(
-                    self.chain,
-                    self.runtime_config,
-                    self._metadata,
-                    self.type_registry,
-                )
 
             runtime_block_hash = self.get_parent_block_hash(block_hash)
 

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -730,7 +730,7 @@ class SubstrateInterface(SubstrateMixin):
         if runtime and runtime.metadata is not None:
             return runtime
 
-        def get_runtime(block_hash,runtime_version) -> Runtime:
+        if True: # keep indenting, this used to be a local function
             self.last_block_hash = block_hash
 
             runtime_block_hash = self.get_parent_block_hash(block_hash)
@@ -796,14 +796,12 @@ class SubstrateInterface(SubstrateMixin):
                     metadata_v15=metadata_v15,
                 )
 
-            return Runtime(
+        runtime = Runtime(
                 self.chain,
                 self.runtime_config,
                 metadata,
                 self.type_registry,
             )
-
-        runtime = get_runtime(block_hash,runtime_version)
         self.runtime_cache.add_item(runtime_version=runtime_version, runtime=runtime)
         return runtime
 

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -70,9 +70,10 @@ class Runtime:
     runtime_config: RuntimeConfigurationObject
     runtime_info = None
     type_registry_preset = None
+    registry: Optional[PortableRegistry] = None
 
     def __init__(
-        self, chain, runtime_config: RuntimeConfigurationObject, metadata, type_registry, metadata_v15=None, runtime_info=None
+        self, chain, runtime_config: RuntimeConfigurationObject, metadata, type_registry, metadata_v15=None, runtime_info=None, registry=None
     ):
         self.config = {}
         self.chain = chain
@@ -81,6 +82,7 @@ class Runtime:
         self.metadata = metadata
         self.metadata_v15 = metadata_v15
         self.runtime_info = runtime_info
+        self.registry = registry
 
     def __str__(self):
         return f"Runtime: {self.chain} | {self.config}"

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -87,93 +87,92 @@ class Runtime:
     def __str__(self):
         return f"Runtime: {self.chain} | {self.config}"
 
-    @property
-    def implements_scaleinfo(self) -> bool:
-        """
-        Returns True if current runtime implementation a `PortableRegistry` (`MetadataV14` and higher)
-        """
-        if self.metadata:
-            return self.metadata.portable_registry is not None
-        else:
-            return False
-
-    def reload_type_registry(
-        self, use_remote_preset: bool = True, auto_discover: bool = True
-    ):
-        """
-        Reload type registry and preset used to instantiate the SubstrateInterface object. Useful to periodically apply
-        changes in type definitions when a runtime upgrade occurred
-
-        Args:
-            use_remote_preset: When True preset is downloaded from Github master, otherwise use files from local
-                installed scalecodec package
-            auto_discover: Whether to automatically discover the type registry presets based on the chain name and the
-                type registry
-        """
-        self.runtime_config.clear_type_registry()
-
-        self.runtime_config.implements_scale_info = self.implements_scaleinfo
-
-        # Load metadata types in runtime configuration
-        self.runtime_config.update_type_registry(load_type_registry_preset(name="core"))
-        self.apply_type_registry_presets(
-            use_remote_preset=use_remote_preset, auto_discover=auto_discover
-        )
-
-    def apply_type_registry_presets(
-        self,
-        use_remote_preset: bool = True,
-        auto_discover: bool = True,
-    ):
-        """
-        Applies type registry presets to the runtime
-
-        Args:
-            use_remote_preset: whether to use presets from remote
-            auto_discover: whether to use presets from local installed scalecodec package
-        """
-        if self.type_registry_preset is not None:
-            # Load type registry according to preset
-            type_registry_preset_dict = load_type_registry_preset(
-                name=self.type_registry_preset, use_remote_preset=use_remote_preset
-            )
-
-            if not type_registry_preset_dict:
-                raise ValueError(
-                    f"Type registry preset '{self.type_registry_preset}' not found"
-                )
-
-        elif auto_discover:
-            # Try to auto discover type registry preset by chain name
-            type_registry_name = self.chain.lower().replace(" ", "-")
-            try:
-                type_registry_preset_dict = load_type_registry_preset(
-                    type_registry_name
-                )
-                self.type_registry_preset = type_registry_name
-            except ValueError:
-                type_registry_preset_dict = None
-
-        else:
-            type_registry_preset_dict = None
-
-        if type_registry_preset_dict:
-            # Load type registries in runtime configuration
-            if self.implements_scaleinfo is False:
-                # Only runtime with no embedded types in metadata need the default set of explicit defined types
-                self.runtime_config.update_type_registry(
-                    load_type_registry_preset(
-                        "legacy", use_remote_preset=use_remote_preset
-                    )
-                )
-
-            if self.type_registry_preset != "legacy":
-                self.runtime_config.update_type_registry(type_registry_preset_dict)
-
-        if self.type_registry:
-            # Load type registries in runtime configuration
-            self.runtime_config.update_type_registry(self.type_registry)
-
+#    @property
+#    def implements_scaleinfo(self) -> bool:
+#        """
+#        Returns True if current runtime implementation a `PortableRegistry` (`MetadataV14` and higher)
+#        """
+#        if self.metadata:
+#            return self.metadata.portable_registry is not None
+#        else:
+#            return False
+#
+#    def reload_type_registry(
+#        self, use_remote_preset: bool = True, auto_discover: bool = True
+#    ):
+#        """
+#        Reload type registry and preset used to instantiate the SubstrateInterface object. Useful to periodically apply
+#        changes in type definitions when a runtime upgrade occurred
+#
+#        Args:
+#            use_remote_preset: When True preset is downloaded from Github master, otherwise use files from local
+#                installed scalecodec package
+#            auto_discover: Whether to automatically discover the type registry presets based on the chain name and the
+#                type registry
+#        """
+#        self.runtime_config.clear_type_registry()
+#
+#        self.runtime_config.implements_scale_info = self.implements_scaleinfo
+#
+#        # Load metadata types in runtime configuration
+#        self.runtime_config.update_type_registry(load_type_registry_preset(name="core"))
+#        self.apply_type_registry_presets(
+#            use_remote_preset=use_remote_preset, auto_discover=auto_discover
+#        )
+#
+#    def apply_type_registry_presets(
+#        self,
+#        use_remote_preset: bool = True,
+#        auto_discover: bool = True,
+#    ):
+#        """
+#        Applies type registry presets to the runtime
+#
+#        Args:
+#            use_remote_preset: whether to use presets from remote
+#            auto_discover: whether to use presets from local installed scalecodec package
+#        """
+#        if self.type_registry_preset is not None:
+#            # Load type registry according to preset
+#            type_registry_preset_dict = load_type_registry_preset(
+#                name=self.type_registry_preset, use_remote_preset=use_remote_preset
+#            )
+#
+#            if not type_registry_preset_dict:
+#                raise ValueError(
+#                    f"Type registry preset '{self.type_registry_preset}' not found"
+#                )
+#
+#        elif auto_discover:
+#            # Try to auto discover type registry preset by chain name
+#            type_registry_name = self.chain.lower().replace(" ", "-")
+#            try:
+#                type_registry_preset_dict = load_type_registry_preset(
+#                    type_registry_name
+#                )
+#                self.type_registry_preset = type_registry_name
+#            except ValueError:
+#                type_registry_preset_dict = None
+#
+#        else:
+#            type_registry_preset_dict = None
+#
+#        if type_registry_preset_dict:
+#            # Load type registries in runtime configuration
+#            if self.implements_scaleinfo is False:
+#                # Only runtime with no embedded types in metadata need the default set of explicit defined types
+#                self.runtime_config.update_type_registry(
+#                    load_type_registry_preset(
+#                        "legacy", use_remote_preset=use_remote_preset
+#                    )
+#                )
+#
+#            if self.type_registry_preset != "legacy":
+#                self.runtime_config.update_type_registry(type_registry_preset_dict)
+#
+#        if self.type_registry:
+#            # Load type registries in runtime configuration
+#            self.runtime_config.update_type_registry(self.type_registry)
 
 class RequestManager:
     RequestResults = dict[Union[str, int], list[Union[ScaleType, dict]]]

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -66,17 +66,21 @@ class Runtime:
     transaction_version = None
     cache_region = None
     metadata = None
+    metadata_v15 = None
     runtime_config: RuntimeConfigurationObject
+    runtime_info = None
     type_registry_preset = None
 
     def __init__(
-        self, chain, runtime_config: RuntimeConfigurationObject, metadata, type_registry
+        self, chain, runtime_config: RuntimeConfigurationObject, metadata, type_registry, metadata_v15=None, runtime_info=None
     ):
         self.config = {}
         self.chain = chain
         self.type_registry = type_registry
         self.runtime_config = runtime_config
         self.metadata = metadata
+        self.metadata_v15 = metadata_v15
+        self.runtime_info = runtime_info
 
     def __str__(self):
         return f"Runtime: {self.chain} | {self.config}"

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -60,8 +60,6 @@ class RuntimeCache:
 
 
 class Runtime:
-    block_hash: str
-    block_id: int
     runtime_version = None
     transaction_version = None
     cache_region = None
@@ -356,7 +354,6 @@ class ScaleObj:
 class SubstrateMixin(ABC):
     type_registry_preset = None
     transaction_version = None
-    block_id: Optional[int] = None
     last_block_hash: Optional[str] = None
     _name: Optional[str] = None
     _properties = None

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -22,26 +22,39 @@ logger = logging.getLogger("async_substrate_interface")
 class RuntimeCache:
     blocks: dict[int, "Runtime"]
     block_hashes: dict[str, "Runtime"]
+    versions: dict[int, "Runtime"]
 
     def __init__(self):
         self.blocks = {}
         self.block_hashes = {}
+        self.versions = {}
 
     def add_item(
-        self, block: Optional[int], block_hash: Optional[str], runtime: "Runtime"
+        self,
+        runtime: "Runtime",
+        block: Optional[int] = None,
+        block_hash: Optional[str] = None,
+        runtime_version: Optional[int] = None,
     ):
         if block is not None:
             self.blocks[block] = runtime
         if block_hash is not None:
             self.block_hashes[block_hash] = runtime
+        if runtime_version is not None:
+            self.versions[runtime_version] = runtime
 
     def retrieve(
-        self, block: Optional[int] = None, block_hash: Optional[str] = None
+        self,
+        block: Optional[int] = None,
+        block_hash: Optional[str] = None,
+        runtime_version: Optional[int] = None
     ) -> Optional["Runtime"]:
         if block is not None:
             return self.blocks.get(block)
         elif block_hash is not None:
             return self.block_hashes.get(block_hash)
+        elif runtime_version is not None:
+            return self.versions.get(runtime_version)
         else:
             return None
 

--- a/test_old_new.py
+++ b/test_old_new.py
@@ -1,0 +1,51 @@
+import sys
+import asyncio
+
+use_async = 0
+if len(sys.argv)>1:
+    use_async = int(sys.argv[1])
+
+n=3
+if len(sys.argv)>2:
+    n = int(sys.argv[2])
+
+import bittensor as bt
+
+coldkey = '5HHHHHzgLnYRvnKkHd45cRUDMHXTSwx7MjUzxBrKbY4JfZWn'
+
+# dtao epoch is 4920350
+
+b_pre = 4920340
+b_post = 4920360
+
+if use_async:
+    st = bt.async_subtensor(network='local')
+    async def main():
+        async with st:
+            print("ss58 format:",st.substrate.ss58_format)
+            print("current block (async):",await st.block)
+            for i in range(n):
+                s0 = await st.get_stake_for_coldkey(coldkey,block=b_post+i)
+                print(f'at block {b_post+i}: {s0}')
+            for i in range(n):
+                s1 = (await st.query_subtensor("TotalColdkeyStake",block=b_pre+i,params=[coldkey])).value
+                print(f'at block {b_pre+i}: {s1}')
+            for i in range(n):
+                s2 = await st.get_stake_for_coldkey(coldkey,block=b_post+i)
+                print(f'at block {b_post+i}: {s2}')
+    asyncio.run(main())
+else:
+    st = bt.subtensor(network='local')
+    print("ss58 format:",st.substrate.ss58_format)
+    print("current block (sync):",st.block)
+    st = bt.subtensor(network='local')
+    for i in range(n):
+        s0 = st.get_stake_for_coldkey(coldkey,block=b_post+i)
+        print(f'at block {b_post+i}: {s0}')
+    for i in range(n):
+        s1 = st.query_subtensor("TotalColdkeyStake",b_pre+i,[coldkey]).value
+        print(f'at block {b_pre+i}: {s1}')
+    for i in range(n):
+        s2 = st.get_stake_for_coldkey(coldkey,block=b_post+i)
+        print(f'at block {b_post+i}: {s2}')
+


### PR DESCRIPTION
First draft of reworked async_substrate_interface/sync_substrate.py

Reworked async_substrate.py along the same lines.

Please find a simple testcase in test_old_new.py (maybe change network to finney) which demonstrates that without the fix, switching between blocks pre- and post-dtao leads to errors.

In total, a lot has changed, but the changes are done step by step in a lot of small commits, such that the thought process can be followed. In case something breaks, this should also help to narrow down the breaking change.

Until `6d0c878c5fb63d6cd9dd6b3d214b6da9da7a71e8` and `6d0c878c5fb63d6cd9dd6b3d214b6da9da7a71e8^` it is mostly refactoring, at which point the bug is pretty obvious, and fixed.

The refactoring boils down to pushing all runtime_version related items to the runtime object, which is cached. The cache uses `runtime_version` as key (so not `block_hash`), while additional caching is done at the point where the runtime_version is looked up for a block_hash/block_id.

Further simplifications and cleanup are possible, but first let's see how this works out.