### PR TITLE
Fixes a memory leak

### DIFF
--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -581,7 +581,8 @@ class SubstrateInterface(SubstrateMixin):
             if not self.ws.close_code:
                 return self.ws
             else:
-                return connect(self.chain_endpoint, max_size=self.ws_max_size)
+                self.ws = connect(self.chain_endpoint, max_size=self.ws_max_size)
+                return self.ws
 
     def get_storage_item(
         self, module: str, storage_function: str, block_hash: str = None


### PR DESCRIPTION
There was a memory leak caused by the `SubstrateInterface.connect` method only ever returning new connections once the init connection closed. 