### PR TITLE
Release/1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.5 /2025-03-06
+
+## What's Changed
+* Fixes a memory leak by @thewhaleking in https://github.com/opentensor/async-substrate-interface/pull/70
+* Backmerge main to staging 104 by @ibraheem-opentensor in https://github.com/opentensor/async-substrate-interface/pull/71
+
+**Full Changelog**: https://github.com/opentensor/async-substrate-interface/compare/v1.0.4...v1.0.5
+
 ## 1.0.4 /2025-03-05
 
 ## What's Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "async-substrate-interface"
-version = "1.0.4"
+version = "1.0.5"
 description = "Asyncio library for interacting with substrate. Mostly API-compatible with py-substrate-interface"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## 1.0.5 /2025-03-06

## What's Changed
* Fixes a memory leak by @thewhaleking in https://github.com/opentensor/async-substrate-interface/pull/70
* Backmerge main to staging 104 by @ibraheem-opentensor in https://github.com/opentensor/async-substrate-interface/pull/71

**Full Changelog**: https://github.com/opentensor/async-substrate-interface/compare/v1.0.4...v1.0.5