### PR TITLE
Experimental: multiprocessing for speeding up query map decodes.

### DIFF
--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -525,7 +525,9 @@ class SubstrateInterface(SubstrateMixin):
         return self
 
     def __del__(self):
-        self.close()
+        self.ws.close()
+        print("DELETING SUBSTATE")
+        # self.ws.protocol.fail(code=1006)  # ABNORMAL_CLOSURE
 
     def initialize(self):
         """

--- a/async_substrate_interface/utils/decoding_attempt.py
+++ b/async_substrate_interface/utils/decoding_attempt.py
@@ -1,0 +1,99 @@
+from scalecodec import ss58_encode
+
+from async_substrate_interface.utils import hex_to_bytes
+from bt_decode import decode as decode_by_type_string, PortableRegistry
+from bittensor_wallet.utils import SS58_FORMAT
+
+
+class ScaleObj:
+    def __init__(self, value):
+        self.value = value
+
+def _decode_scale_with_runtime(
+        type_string: str,
+        scale_bytes: bytes,
+        runtime_registry: "Runtime",
+        return_scale_obj: bool = False
+):
+    if scale_bytes == b"":
+        return None
+    if type_string == "scale_info::0":  # Is an AccountId
+        # Decode AccountId bytes to SS58 address
+        return ss58_encode(scale_bytes, SS58_FORMAT)
+    else:
+        obj = decode_by_type_string(type_string, runtime_registry, scale_bytes)
+    if return_scale_obj:
+        return ScaleObj(obj)
+    else:
+        return obj
+
+def _decode_query_map(result_group_changes, prefix, runtime_registry,
+                      param_types, params, value_type, key_hashers, ignore_decoding_errors):
+    def concat_hash_len(key_hasher: str) -> int:
+        """
+        Helper function to avoid if statements
+        """
+        if key_hasher == "Blake2_128Concat":
+            return 16
+        elif key_hasher == "Twox64Concat":
+            return 8
+        elif key_hasher == "Identity":
+            return 0
+        else:
+            raise ValueError("Unsupported hash type")
+
+    hex_to_bytes_ = hex_to_bytes
+    runtime_registry = PortableRegistry.from_json(runtime_registry)
+
+    result = []
+    for item in result_group_changes:
+        try:
+            # Determine type string
+            key_type_string = []
+            for n in range(len(params), len(param_types)):
+                key_type_string.append(
+                    f"[u8; {concat_hash_len(key_hashers[n])}]"
+                )
+                key_type_string.append(param_types[n])
+
+            item_key_obj = _decode_scale_with_runtime(
+                f"({', '.join(key_type_string)})",
+                bytes.fromhex(item[0][len(prefix):]),
+                runtime_registry,
+                False
+            )
+
+            # strip key_hashers to use as item key
+            if len(param_types) - len(params) == 1:
+                item_key = item_key_obj[1]
+            else:
+                item_key = tuple(
+                    item_key_obj[key + 1]
+                    for key in range(len(params), len(param_types) + 1, 2)
+                )
+
+        except Exception as _:
+            if not ignore_decoding_errors:
+                raise
+            item_key = None
+
+        try:
+            item_bytes = hex_to_bytes_(item[1])
+
+            item_value = _decode_scale_with_runtime(
+                value_type,
+                item_bytes,
+                runtime_registry,
+                True
+            )
+
+        except Exception as _:
+            if not ignore_decoding_errors:
+                raise
+            item_value = None
+        result.append([item_key, item_value])
+    return result
+
+
+if __name__ == "__main__":
+    pass


### PR DESCRIPTION
Works (mostly) with the following snippet:

```python
import asyncio
from concurrent.futures import ProcessPoolExecutor
from async_substrate_interface.async_substrate import AsyncSubstrateInterface
from bittensor.core.chain_data import decode_account_id
from bittensor.core.settings import SS58_FORMAT
import time


async def fish():
    async def exhaust(qmr):
        r = []
        async for k, v in await qmr:
            r.append((k, v))
        return r

    start = time.time()
    executor = ProcessPoolExecutor(max_workers=None)
    async with AsyncSubstrateInterface("wss://entrypoint-finney.opentensor.ai:443", ss58_format=SS58_FORMAT) as substrate:
        block_hash = await substrate.get_chain_head()
        tasks = [substrate.query_map("SubtensorModule", "TaoDividendsPerSubnet", [netuid], block_hash=block_hash, executor=executor) for
                 netuid in range(1, 51)]
        tasks = [exhaust(task) for task in tasks]
        print(time.time() - start)
        results_dicts_list = []
        for future in asyncio.as_completed(tasks):
            result = await future
            results_dicts_list.extend([{decode_account_id(k): v.value} for k, v in result])

    elapsed = time.time() - start
    print(f"time elapsed: {elapsed}")

    print("Async Results", len(results_dicts_list))
    time.sleep(5)
    try:
        executor.shutdown(wait=False, cancel_futures=True)
    except Exception:
        pass


if __name__ == '__main__':
    asyncio.run(fish())
```

Note that during the `executor.shutdown` line, we get lots of EOF errors, and idk why:
<details>
  <summary>
   output
  </summary>
3.92362904548645
time elapsed: 19.864284992218018
Async Results 14803
Exception in thread Exception in thread Thread-2 (_monitor):
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
Exception in thread Thread-2 (_monitor):
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
Exception in thread Thread-2 (_monitor):
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
Thread-2 (_monitor):
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
Exception in thread Exception in thread Thread-2 (_monitor)Exception in thread Thread-2 (_monitor)Thread-2 (_monitor):
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
:
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
Exception in thread :
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
Thread-2 (_monitor):
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
Exception in thread Thread-2 (_monitor):
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
Exception in thread Thread-2 (_monitor):
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
    self.run()
        self.run()self.run()    self.run()    
self.run()
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1012, in run

      File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1012, in run
    self.run()
self.run()  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1012, in run


  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1012, in run
    self.run()
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1012, in run
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1012, in run
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1012, in run
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1012, in run
          File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1012, in run
    self.run()self._target(*self._args, **self._kwargs)

    self._target(*self._args, **self._kwargs)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/threading.py", line 1012, in run
        self._target(*self._args, **self._kwargs)self._target(*self._args, **self._kwargs)self._target(*self._args, **self._kwargs)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1577, in _monitor

    self._target(*self._args, **self._kwargs)  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1577, in _monitor

  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1577, in _monitor
    self._target(*self._args, **self._kwargs)

  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1577, in _monitor
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1577, in _monitor
    self._target(*self._args, **self._kwargs)
    self._target(*self._args, **self._kwargs)
    self._target(*self._args, **self._kwargs)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1577, in _monitor
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1577, in _monitor
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1577, in _monitor
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1577, in _monitor
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1577, in _monitor
    record = self.dequeue(True)
    record = self.dequeue(True)    record = self.dequeue(True)
     record = self.dequeue(True) 
           record = self.dequeue(True)record = self.dequeue(True)

      
    record = self.dequeue(True)  
      record = self.dequeue(True)     
       record = self.dequeue(True) record = self.dequeue(True) 
   
                                ^  ^          ^          ^    ^     ^  ^ ^^ ^        ^     ^^^ ^^^ ^ ^ ^ ^ ^  ^  ^^  ^^    ^^ ^^ ^^^^ ^^^^^ ^ ^^^^^^^^^^^^^^^ ^^^ ^^^^^^ ^^ ^^^^^^^^^^^^^^^^ ^^^^^^^^^^
^^
^^^^^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1526, in dequeue
^^^^^^^^^^^^^^^^^^^^^^^^^^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1526, in dequeue
^^^^^^^^^^^^^^^^^^^^^^^^^
^^^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1526, in dequeue

^^^

^^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1526, in dequeue
^^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1526, in dequeue
^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1526, in dequeue
^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1526, in dequeue
^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1526, in dequeue
^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1526, in dequeue

  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/logging/handlers.py", line 1526, in dequeue
    return self.queue.get(block)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/queues.py", line 103, in get
    return self.queue.get(block)
    return self.queue.get(block)
                     return self.queue.get(block)return self.queue.get(block)
 
       ^^^^^^^   ^ ^ ^^      return self.queue.get(block)
 ^^^     ^^^^^ ^ return self.queue.get(block)^    return self.queue.get(block)
    return self.queue.get(block)
^ 
^^^ ^ ^ ^ ^ ^ ^ ^ ^^^ ^ ^ 
 ^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/queues.py", line 103, in get
^     ^^ ^^^^^               ^^  ^^^^^^^^^      ^^return self.queue.get(block)^   
  ^   ^^^^ ^
  ^ ^ ^^^^^^^^^^ ^^^^   File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/queues.py", line 103, in get
^ ^^^^^^^^^
^  ^^^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/queues.py", line 103, in get
^^^^    ^    ^^^^^^^^^^ ^^^ ^^^res = self._recv_bytes()
^^     ^res = self._recv_bytes()

 ^res = self._recv_bytes()      File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/queues.py", line 103, in get
   ^    ^ ^ ^ ^^^res = self._recv_bytes()^^^   
^  ^
^^^^^^^^^ ^  ^^^    ^     
 res = self._recv_bytes()  ^^ ^^^^^^^^^
 ^^^^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/queues.py", line 103, in get
^ ^ ^ ^ ^
  ^  ^   ^^ ^      ^res = self._recv_bytes()  
         ^ ^
^^ ^^^
^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/queues.py", line 103, in get
^ ^^^^^ ^^^^^^^^^^^^ ^^^^^^^^^^^^^^^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/queues.py", line 103, in get
^^^^^^ ^^^^^^^^^^
^^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/queues.py", line 103, in get
^ ^^^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/queues.py", line 103, in get
^^^    ^^

  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 216, in recv_bytes
^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 216, in recv_bytes
^res = self._recv_bytes()^    ^res = self._recv_bytes()^^^ ^    
res = self._recv_bytes()^

^
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 216, in recv_bytes
   ^    ^  ^ ^ ^^^^^ ^^ ^^ ^^^^    ^^^ ^^res = self._recv_bytes()^
   ^  ^^ ^^^^^^^^^^  ^ ^^ ^
^^^^^  ^ ^ ^ ^^^^^^^  ^     ^^ ^^^^^ ^ ^^  
^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 216, in recv_bytes
     ^
^^^^^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 216, in recv_bytes
^    ^^^^buf = self._recv_bytes(maxlength) ^
^buf = self._recv_bytes(maxlength)^ 
^^^
^^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 216, in recv_bytes
       File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 216, in recv_bytes
^^buf = self._recv_bytes(maxlength)^^^
^^     buf = self._recv_bytes(maxlength)^
^^^^^    ^  ^^ ^   ^ buf = self._recv_bytes(maxlength)^^ 
   ^ ^ ^^  ^  ^
 ^^^^    ^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 216, in recv_bytes
 buf = self._recv_bytes(maxlength)^ 

     
   ^       ^ ^ ^  ^^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 216, in recv_bytes
^^^          File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 216, in recv_bytes
 ^^^^^^^^^^ ^buf = self._recv_bytes(maxlength)^^
^^^^^^^  ^    ^ ^   ^   ^^^buf = self._recv_bytes(maxlength)   
  ^^^ ^ ^     ^^ ^^buf = self._recv_bytes(maxlength)
^^^^^^^^^^^ ^       ^^ ^^ ^ ^^ ^^buf = self._recv_bytes(maxlength)
^^ ^ ^ ^ ^^^ ^^ ^^ ^^ ^^^^^ ^ ^^ ^ ^ 
  ^  ^^     ^ ^^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 430, in _recv_bytes
^^^^ ^ ^^^ ^^ ^^ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
^^    ^^^^^^^^
^buf = self._recv(4)^^^^^^^^^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 430, in _recv_bytes
^^^^^
^^^^^^
^^^^^^^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 430, in _recv_bytes
^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 430, in _recv_bytes
  ^^^^^^^^^^ ^^^ ^^ ^^^   ^^^ ^^^
^    buf = self._recv(4)
^ ^^^^ ^^ ^^  ^ ^^^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 430, in _recv_bytes
^^^^        buf = self._recv(4)
^ ^^^^ ^ ^^ ^ ^^
^buf = self._recv(4)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 430, in _recv_bytes
^^^^^^^^^^^^^^
^^ ^^
^ ^^^
^ 
   File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 430, in _recv_bytes
   File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 399, in _recv
^^^^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 430, in _recv_bytes
^   File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 430, in _recv_bytes
^          ^     ^^buf = self._recv(4)^^^
^ ^buf = self._recv(4)^^

  ^   File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 430, in _recv_bytes
^^  ^  ^  
 ^ ^^^^ ^^^ ^^ ^^ ^ ^^^^^^^

      File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 399, in _recv
raise EOFError    File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 399, in _recv
   File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 399, in _recv

     buf = self._recv(4) 
     buf = self._recv(4)
^^EOFError^^      
 ^^^ ^ ^^^^    ^
buf = self._recv(4)   File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 399, in _recv

      raise EOFError
         buf = self._recv(4)      ^^^^^    
raise EOFErrorEOFError^
 ^ 
^ ^^ ^EOFError
      raise EOFError^^
^^ ^^^^^  ^ ^EOFError  ^ ^  ^ 
^ ^^ ^^^^^^^^    ^ raise EOFError^[0m
^^^^^
[0m
^  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 399, in _recv
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 399, in _recv
^
^^ EOFError^[0m  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 399, in _recv
^ ^^^^^^^^[0m
^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 399, in _recv
    raise EOFError
EOFError
^^^    raise EOFError
EOFError
^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/connection.py", line 399, in _recv
[0m    raise EOFError[0m
    raise EOFError
EOFError
EOFError
[0m    raise EOFError
EOFError
[0m[0m[0m[0m
Process finished with exit code 0
</details>