### PR TITLE
Updates `_load_registry_type_map`

### DIFF
--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -633,12 +633,8 @@ class SubstrateMixin(ABC):
             type_id = type_entry["id"]
             type_def = type_entry["type"]["def"]
             type_path = type_entry["type"].get("path")
-            if type_id == 514:
-                print(type_id)
-
             if type_entry.get("params") or "variant" in type_def:
                 continue
-
             if type_path:
                 type_name = type_path[-1]
                 registry_type_map[type_name] = type_id
@@ -862,10 +858,6 @@ class SubstrateMixin(ABC):
                 )
             except KeyError:
                 vec_acct_id = "scale_info::152"
-            import json
-
-            with open("registry_final_pass_elif.json", "w") as json_file:
-                json.dump(self.registry_type_map, json_file, indent=4)
             try:
                 optional_acct_u16 = f"scale_info::{self.registry_type_map['Option<(AccountId32, u16)>']}"
             except KeyError:

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -718,8 +718,6 @@ class SubstrateMixin(ABC):
         while resolved_type and pending_ids:
             resolved_type = False
             for type_id in list(pending_ids):
-                if type_id == 514:
-                    print(type_id)
                 name = resolve_type_definition(type_id)
                 if name is not None:
                     type_id_to_name[type_id] = name


### PR DESCRIPTION
## Old

- Single-pass approach: If a type depended on another type not yet processed, it was left unresolved.
- Relied on order: Some types were skipped because they weren’t recognized in time.
- Nested generics (like some Option<Type>) often stayed unresolved because of this.
- Incomplete arrays/sequences: Definitions weren’t fully expanded.

## New

- Two-pass resolution: First map simple types; then iteratively resolve nested/complex ones.
- Iterative handling: Re-check pending types until none remain, ensuring dependencies get picked up.
- All generics resolved: Options and similar now properly map their inner types.

