### PR TITLE
Support async key implementations

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -22,8 +22,6 @@ from typing import (
 )
 
 import asyncstdlib as a
-from bittensor_wallet.keypair import Keypair
-from bittensor_wallet.utils import SS58_FORMAT
 from bt_decode import MetadataV15, PortableRegistry, decode as decode_by_type_string
 from scalecodec.base import ScaleBytes, ScaleType, RuntimeConfigurationObject
 from scalecodec.types import (
@@ -35,11 +33,13 @@ from scalecodec.types import (
 from websockets.asyncio.client import connect
 from websockets.exceptions import ConnectionClosed
 
+from async_substrate_interface.const import SS58_FORMAT
 from async_substrate_interface.errors import (
     SubstrateRequestException,
     ExtrinsicNotFound,
     BlockNotFound,
 )
+from async_substrate_interface.protocols import Keypair
 from async_substrate_interface.types import (
     ScaleObj,
     RequestManager,
@@ -2406,6 +2406,8 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
             # Sign payload
             signature = keypair.sign(signature_payload)
+            if inspect.isawaitable(signature):
+                signature = await signature
 
         # Create extrinsic
         extrinsic = self.runtime_config.create_scale_object(
@@ -2691,9 +2693,6 @@ class AsyncSubstrateInterface(SubstrateMixin):
         # Check requirements
         if not isinstance(call, GenericCall):
             raise TypeError("'call' must be of type Call")
-
-        if not isinstance(keypair, Keypair):
-            raise TypeError("'keypair' must be of type Keypair")
 
         # No valid signature is required for fee estimation
         signature = "0x" + "00" * 64

--- a/async_substrate_interface/const.py
+++ b/async_substrate_interface/const.py
@@ -1,0 +1,4 @@
+
+
+# Re-define SS58 format here to remove unnecessary dependencies.
+SS58_FORMAT = 42

--- a/async_substrate_interface/protocols.py
+++ b/async_substrate_interface/protocols.py
@@ -1,0 +1,43 @@
+from typing import Protocol
+
+
+__all__: list[str] = [
+    'Keypair'
+]
+
+
+# For reference only
+# class KeypairType:
+#     """
+#     Type of cryptography, used in `Keypair` instance to encrypt and sign data
+# 
+#     * ED25519 = 0
+#     * SR25519 = 1
+#     * ECDSA = 2
+# 
+#     """
+#     ED25519 = 0
+#     SR25519 = 1
+#     ECDSA = 2
+
+
+class Keypair(Protocol):
+
+    @property
+    def crypto_type(self) -> int:
+        ...
+
+    @property
+    def public_key(self) -> bytes | None:
+        ...
+
+    @property
+    def ss58_address(self) -> str:
+        ...
+
+    @property
+    def ss58_format(self) -> int:
+        ...
+
+    def sign(self, data: bytes | str) -> bytes:
+        ...

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -4,8 +4,6 @@ import random
 from hashlib import blake2b
 from typing import Optional, Union, Callable, Any
 
-from bittensor_wallet.keypair import Keypair
-from bittensor_wallet.utils import SS58_FORMAT
 from bt_decode import MetadataV15, PortableRegistry, decode as decode_by_type_string
 from scalecodec import (
     GenericCall,
@@ -17,11 +15,13 @@ from scalecodec.base import RuntimeConfigurationObject, ScaleBytes, ScaleType
 from websockets.sync.client import connect
 from websockets.exceptions import ConnectionClosed
 
+from async_substrate_interface.const import SS58_FORMAT
 from async_substrate_interface.errors import (
     ExtrinsicNotFound,
     SubstrateRequestException,
     BlockNotFound,
 )
+from async_substrate_interface.protocols import Keypair
 from async_substrate_interface.types import (
     SubstrateMixin,
     RuntimeCache,

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -7,12 +7,12 @@ from datetime import datetime
 from typing import Optional, Union, Any
 
 from bt_decode import PortableRegistry, encode as encode_by_type_string
-from bittensor_wallet.utils import SS58_FORMAT
 from scalecodec import ss58_encode, ss58_decode, is_valid_ss58_address
 from scalecodec.base import RuntimeConfigurationObject, ScaleBytes
 from scalecodec.type_registry import load_type_registry_preset
 from scalecodec.types import GenericCall, ScaleType
 
+from .const import SS58_FORMAT
 from .utils import json
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ keywords = ["substrate", "development", "bittensor"]
 dependencies = [
   "wheel",
   "asyncstdlib~=3.13.0",
-  "bittensor-wallet>=2.1.3",
   "bt-decode==v0.5.0",
   "scalecodec~=1.2.11",
   "websockets>=14.1",


### PR DESCRIPTION
This pull request abstracts the Keypair used to sign transactions. This allows the integration of cryptographic backends that require async calls (such as HSMs in cloud environments).

The bittensor_wallet.Keypair type is replaced by a protocol that defines its properties and methods. In `create_signed_extrinsic` it is checked if the result of `sign()` is awaitable, and if so the result is
properly awaited.