### PR TITLE
State-Safe RNG

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -7,7 +7,6 @@ regard to how to instantiate and use it.
 import asyncio
 import inspect
 import logging
-import random
 import ssl
 import time
 from hashlib import blake2b
@@ -48,7 +47,12 @@ from async_substrate_interface.types import (
     SubstrateMixin,
     Preprocessed,
 )
-from async_substrate_interface.utils import hex_to_bytes, json, get_next_id
+from async_substrate_interface.utils import (
+    hex_to_bytes,
+    json,
+    get_next_id,
+    rng as random,
+)
 from async_substrate_interface.utils.cache import async_sql_lru_cache
 from async_substrate_interface.utils.decoding import (
     _determine_if_old_runtime_call,

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -1,6 +1,5 @@
 import functools
 import logging
-import random
 from hashlib import blake2b
 from typing import Optional, Union, Callable, Any
 
@@ -30,7 +29,12 @@ from async_substrate_interface.types import (
     Preprocessed,
     ScaleObj,
 )
-from async_substrate_interface.utils import hex_to_bytes, json, get_next_id
+from async_substrate_interface.utils import (
+    hex_to_bytes,
+    json,
+    get_next_id,
+    rng as random,
+)
 from async_substrate_interface.utils.decoding import (
     _determine_if_old_runtime_call,
     _bt_decode_to_dict_or_list,

--- a/async_substrate_interface/utils/__init__.py
+++ b/async_substrate_interface/utils/__init__.py
@@ -5,13 +5,15 @@ import string
 
 id_cycle = cycle(range(1, 999))
 
+rng = random.Random()
+
 
 def get_next_id() -> str:
     """
     Generates a pseudo-random ID by returning the next int of a range from 1-998 prepended with
     two random ascii characters.
     """
-    random_letters = "".join(random.choices(string.ascii_letters, k=2))
+    random_letters = "".join(rng.choices(string.ascii_letters, k=2))
     return f"{random_letters}{next(id_cycle)}"
 
 


### PR DESCRIPTION
Uses an instantiated `random.Random` instance to generate the random numbers/letters used for creating payload IDs rather than the hidden instantiation (see: https://docs.python.org/3/library/random.html) which can influence the state of the global random number generator used elsewhere.

CC @chain-cpu