### PR TITLE
Expose `_get_block_handler` publicly

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -1394,6 +1394,8 @@ class AsyncSubstrateInterface(SubstrateMixin):
                     response["result"]["block"], block_data_hash=block_hash
                 )
 
+    get_block_handler = _get_block_handler
+
     async def get_block(
         self,
         block_hash: Optional[str] = None,

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -1141,6 +1141,8 @@ class SubstrateInterface(SubstrateMixin):
                     response["result"]["block"], block_data_hash=block_hash
                 )
 
+    get_block_handler = _get_block_handler
+
     def get_block(
         self,
         block_hash: Optional[str] = None,


### PR DESCRIPTION
Exposes `_get_block_handler` publicly in both async and sync substrate interfaces.

Resolves #106 