### PR TITLE
safe `__del__`

### DIFF
--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -532,8 +532,10 @@ class SubstrateInterface(SubstrateMixin):
         return self
 
     def __del__(self):
-        self.ws.close()
-        print("DELETING SUBSTATE")
+        try:
+            self.ws.close()
+        except AttributeError:
+            pass
         # self.ws.protocol.fail(code=1006)  # ABNORMAL_CLOSURE
 
     def initialize(self):


### PR DESCRIPTION
Wraps the websocket closure in `SubstrateInterface.__del__` in a try:except catch to ensure it doesn't raise wonky errors such as in the case of instantiating the object with `_mock=True`

Fixes #109 