### PR TITLE
Add MetadataAtVersionNotFound error

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -39,6 +39,7 @@ from async_substrate_interface.errors import (
     ExtrinsicNotFound,
     BlockNotFound,
     MaxRetriesExceeded,
+    MetadataAtVersionNotFound,
 )
 from async_substrate_interface.protocols import Keypair
 from async_substrate_interface.types import (
@@ -817,10 +818,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 "Client error: Execution failed: Other: Exported method Metadata_metadata_at_version is not found"
                 in e.args
             ):
-                raise SubstrateRequestException(
-                    "You are attempting to call a block too old for this version of async-substrate-interface. Please"
-                    " instead use legacy py-substrate-interface for these very old blocks."
-                )
+                raise MetadataAtVersionNotFound
             else:
                 raise e
         metadata_option_hex_str = metadata_rpc_result["result"]

--- a/async_substrate_interface/errors.py
+++ b/async_substrate_interface/errors.py
@@ -12,6 +12,16 @@ class MaxRetriesExceeded(SubstrateRequestException):
     pass
 
 
+class MetadataAtVersionNotFound(SubstrateRequestException):
+    def __init__(self):
+        message = (
+            "Exported method Metadata_metadata_at_version is not found. This indicates the block is quite old, and is"
+            "not supported by async-substrate-interface. If you need this, we recommend using the legacy "
+            "substrate-interface (https://github.com/JAMdotTech/py-polkadot-sdk)."
+        )
+        super().__init__(message)
+
+
 class StorageFunctionNotFound(ValueError):
     pass
 


### PR DESCRIPTION
`async-substrate-interface` was not designed to work with old blocks. This adds an error that will correctly inform the user when they're attempting to query the metadata v15 for a very old block [in the case of #112 a block that is 2_499_439 blocks (about a year) old].