### PR TITLE
Allows for using new account ID encoding with flag

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -3254,7 +3254,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                     value_type,
                     key_hashers,
                     ignore_decoding_errors,
-                    self.legacy_account_id_decode,
+                    legacy_account_id=self.legacy_account_id_decode,
                 )
         return AsyncQueryMapResult(
             records=result,

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -3653,7 +3653,7 @@ async def get_async_substrate_interface(
     max_retries: int = 5,
     retry_timeout: float = 60.0,
     _mock: bool = False,
-    legacy_account_id_decode: bool = True
+    legacy_account_id_decode: bool = True,
 ) -> "AsyncSubstrateInterface":
     """
     Factory function for creating an initialized AsyncSubstrateInterface
@@ -3668,7 +3668,7 @@ async def get_async_substrate_interface(
         max_retries,
         retry_timeout,
         _mock,
-        legacy_account_id_decode=legacy_account_id_decode
+        legacy_account_id_decode=legacy_account_id_decode,
     )
     await substrate.initialize()
     return substrate

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -3653,6 +3653,7 @@ async def get_async_substrate_interface(
     max_retries: int = 5,
     retry_timeout: float = 60.0,
     _mock: bool = False,
+    legacy_account_id_decode: bool = True
 ) -> "AsyncSubstrateInterface":
     """
     Factory function for creating an initialized AsyncSubstrateInterface
@@ -3667,6 +3668,7 @@ async def get_async_substrate_interface(
         max_retries,
         retry_timeout,
         _mock,
+        legacy_account_id_decode=legacy_account_id_decode
     )
     await substrate.initialize()
     return substrate

--- a/async_substrate_interface/substrate_addons.py
+++ b/async_substrate_interface/substrate_addons.py
@@ -117,7 +117,7 @@ class RetrySyncSubstrate(SubstrateInterface):
         max_retries: int = 5,
         retry_timeout: float = 60.0,
         _mock: bool = False,
-        legacy_account_id_decode: bool = True
+        legacy_account_id_decode: bool = True,
     ):
         fallback_chains = fallback_chains or []
         self.fallback_chains = (
@@ -148,7 +148,7 @@ class RetrySyncSubstrate(SubstrateInterface):
                     _mock=_mock,
                     retry_timeout=retry_timeout,
                     max_retries=max_retries,
-                    legacy_account_id_decode=self.legacy_account_id_decode
+                    legacy_account_id_decode=self.legacy_account_id_decode,
                 )
                 initialized = True
                 logger.info(f"Connected to {chain_url}")
@@ -246,6 +246,7 @@ class RetryAsyncSubstrate(AsyncSubstrateInterface):
         max_retries: int = 5,
         retry_timeout: float = 60.0,
         _mock: bool = False,
+        legacy_account_id_decode: bool = True,
     ):
         fallback_chains = fallback_chains or []
         self.fallback_chains = (
@@ -268,6 +269,7 @@ class RetryAsyncSubstrate(AsyncSubstrateInterface):
             _mock=_mock,
             retry_timeout=retry_timeout,
             max_retries=max_retries,
+            legacy_account_id_decode=legacy_account_id_decode,
         )
         self._original_methods = {
             method: getattr(self, method) for method in RETRY_METHODS

--- a/async_substrate_interface/substrate_addons.py
+++ b/async_substrate_interface/substrate_addons.py
@@ -117,6 +117,7 @@ class RetrySyncSubstrate(SubstrateInterface):
         max_retries: int = 5,
         retry_timeout: float = 60.0,
         _mock: bool = False,
+        legacy_account_id_decode: bool = True
     ):
         fallback_chains = fallback_chains or []
         self.fallback_chains = (
@@ -131,6 +132,7 @@ class RetrySyncSubstrate(SubstrateInterface):
         self.max_retries = max_retries
         self.chain_endpoint = url
         self.url = url
+        self.legacy_account_id_decode = legacy_account_id_decode
         initialized = False
         for chain_url in [url] + fallback_chains:
             try:
@@ -146,6 +148,7 @@ class RetrySyncSubstrate(SubstrateInterface):
                     _mock=_mock,
                     retry_timeout=retry_timeout,
                     max_retries=max_retries,
+                    legacy_account_id_decode=self.legacy_account_id_decode
                 )
                 initialized = True
                 logger.info(f"Connected to {chain_url}")

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -2965,7 +2965,7 @@ class SubstrateInterface(SubstrateMixin):
                     value_type,
                     key_hashers,
                     ignore_decoding_errors,
-                    self.legacy_account_id_decode,
+                    legacy_account_id=self.legacy_account_id_decode,
                 )
         return QueryMapResult(
             records=result,

--- a/async_substrate_interface/utils/decoding.py
+++ b/async_substrate_interface/utils/decoding.py
@@ -114,7 +114,7 @@ def decode_query_map(
         pre_decoded_key_types + pre_decoded_value_types,
         pre_decoded_keys + pre_decoded_values,
         runtime.registry,
-        legacy_account_id,
+        legacy_account_id=legacy_account_id,
     )
     middl_index = len(all_decoded) // 2
     decoded_keys = all_decoded[:middl_index]

--- a/async_substrate_interface/utils/decoding.py
+++ b/async_substrate_interface/utils/decoding.py
@@ -1,8 +1,6 @@
 from typing import Union, TYPE_CHECKING
 
 from bt_decode import AxonInfo, PrometheusInfo, decode_list
-from scalecodec import ss58_encode
-from bittensor_wallet.utils import SS58_FORMAT
 
 from async_substrate_interface.utils import hex_to_bytes
 from async_substrate_interface.types import ScaleObj
@@ -59,8 +57,11 @@ def _decode_scale_list_with_runtime(
     scale_bytes_list: list[bytes],
     runtime_registry,
     return_scale_obj: bool = False,
+    legacy_account_id: bool = True,
 ):
-    obj = decode_list(type_strings, runtime_registry, scale_bytes_list)
+    obj = decode_list(
+        type_strings, runtime_registry, scale_bytes_list, legacy_account_id
+    )
     if return_scale_obj:
         return [ScaleObj(x) for x in obj]
     else:
@@ -76,6 +77,7 @@ def decode_query_map(
     value_type,
     key_hashers,
     ignore_decoding_errors,
+    legacy_account_id: bool = True,
 ):
     def concat_hash_len(key_hasher: str) -> int:
         """
@@ -112,6 +114,7 @@ def decode_query_map(
         pre_decoded_key_types + pre_decoded_value_types,
         pre_decoded_keys + pre_decoded_values,
         runtime.registry,
+        legacy_account_id,
     )
     middl_index = len(all_decoded) // 2
     decoded_keys = all_decoded[:middl_index]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ keywords = ["substrate", "development", "bittensor"]
 dependencies = [
   "wheel",
   "asyncstdlib~=3.13.0",
-  "bt-decode==v0.6.0",
+  "bt-decode==0.7.0",
   "scalecodec~=1.2.11",
   "websockets>=14.1",
   "xxhash"


### PR DESCRIPTION
Fixes #61 

(requires bt-decode 0.7 to be released first)