### PR TITLE
Edge Case Fixes

### DIFF
--- a/.github/workflows/run-async-substrate-interface-tests.yml
+++ b/.github/workflows/run-async-substrate-interface-tests.yml
@@ -1,34 +1,81 @@
-name: Run Unit Tests
+name: Run Tests
 
 on:
   push:
-    branches:
-      - main
-      - staging
+    branches: [main, staging]
   pull_request:
-    branches:
-      - main
-      - staging
+    branches: [main, staging]
+  workflow_dispatch:
 
 jobs:
-  run-tests:
+  find-tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository
+      - name: Check-out repository
+        uses: actions/checkout@v4
+
+      - name: Find test files
+        id: get-tests
+        run: |
+          test_files=$(find tests -name "test*.py" | jq -R -s -c 'split("\n") | map(select(. != ""))')
+          echo "::set-output name=test-files::$test_files"
+
+  pull-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+
+      - name: Pull Docker Image
+        run: docker pull ghcr.io/opentensor/subtensor-localnet:devnet-ready
+
+      - name: Save Docker Image to Cache
+        run: docker save -o subtensor-localnet.tar ghcr.io/opentensor/subtensor-localnet:devnet-ready
+
+      - name: Upload Docker Image as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: subtensor-localnet
+          path: subtensor-localnet.tar
+
+  run-unit-tests:
+    name: ${{ matrix.test-file }} / Python ${{ matrix.python-version }}
+    needs:
+      - find-tests
+      - pull-docker-image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      max-parallel: 32
+      matrix:
+        test-file: ${{ fromJson(needs.find-tests.outputs.test-files) }}
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Check-out repository
         uses: actions/checkout@v4
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          python-version: 3.13
+          python-version: ${{ matrix.python-version }}
 
-      - name: install dependencies
+      - name: Install dependencies
         run: |
           uv venv .venv
           source .venv/bin/activate
           uv pip install .[dev]
 
+      - name: Download Docker Image
+        uses: actions/download-artifact@v4
+        with:
+          name: subtensor-localnet
+
+      - name: Load Docker Image
+        run: docker load -i subtensor-localnet.tar
+
       - name: Run pytest
         run: |
           source .venv/bin/activate
-          pytest tests
+          uv run pytest ${{ matrix.test-file }} -v -s

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -539,7 +539,7 @@ class Websocket:
                 "You are instantiating the AsyncSubstrateInterface Websocket outside of an event loop. "
                 "Verify this is intended."
             )
-            now = asyncio.new_event_loop().time()
+            now = 0.0
         self.last_received = now
         self.last_sent = now
 

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -619,6 +619,7 @@ class Websocket:
                 self._open_subscriptions -= 1
             if "id" in response:
                 self._received[response["id"]] = response
+                self._in_use_ids.remove(response["id"])
             elif "params" in response:
                 self._received[response["params"]["subscription"]] = response
             else:
@@ -674,7 +675,6 @@ class Websocket:
         """
         try:
             item = self._received.pop(item_id)
-            self._in_use_ids.remove(item_id)
             self.max_subscriptions.release()
             return item
         except KeyError:

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -732,6 +732,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
             )
         else:
             self.ws = AsyncMock(spec=Websocket)
+
         self._lock = asyncio.Lock()
         self.config = {
             "use_remote_preset": use_remote_preset,

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -538,6 +538,9 @@ class Websocket:
                 "You are instantiating the AsyncSubstrateInterface Websocket outside of an event loop. "
                 "Verify this is intended."
             )
+            # default value for in case there's no running asyncio loop
+            # this really doesn't matter in most cases, as it's only used for comparison on the first call to
+            # see how long it's been since the last call
             now = 0.0
         self.last_received = now
         self.last_sent = now

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -673,7 +673,7 @@ class Websocket:
             self.max_subscriptions.release()
             return item
         except KeyError:
-            await asyncio.sleep(0.001)
+            await asyncio.sleep(0.1)
             return None
 
 
@@ -2151,14 +2151,14 @@ class AsyncSubstrateInterface(SubstrateMixin):
                     and current_time - self.ws.last_sent >= self.retry_timeout
                 ):
                     if attempt >= self.max_retries:
-                        logger.warning(
+                        logger.error(
                             f"Timed out waiting for RPC requests {attempt} times. Exiting."
                         )
                         raise MaxRetriesExceeded("Max retries reached.")
                     else:
                         self.ws.last_received = time.time()
                         await self.ws.connect(force=True)
-                        logger.error(
+                        logger.warning(
                             f"Timed out waiting for RPC requests. "
                             f"Retrying attempt {attempt + 1} of {self.max_retries}"
                         )

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -2497,13 +2497,13 @@ class SubstrateInterface(SubstrateMixin):
         Returns:
              ScaleType from the runtime call
         """
-        self.init_runtime(block_hash=block_hash)
+        runtime = self.init_runtime(block_hash=block_hash)
 
         if params is None:
             params = {}
 
         try:
-            metadata_v15_value = self.runtime.metadata_v15.value()
+            metadata_v15_value = runtime.metadata_v15.value()
 
             apis = {entry["name"]: entry for entry in metadata_v15_value["apis"]}
             api_entry = apis[api]

--- a/tests/unit_tests/asyncio_/test_substrate_interface.py
+++ b/tests/unit_tests/asyncio_/test_substrate_interface.py
@@ -1,4 +1,4 @@
-import unittest.mock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from websockets.exceptions import InvalidURI
@@ -24,42 +24,70 @@ async def test_invalid_url_raises_exception():
 @pytest.mark.asyncio
 async def test_runtime_call(monkeypatch):
     substrate = AsyncSubstrateInterface("ws://localhost", _mock=True)
-    substrate._metadata = unittest.mock.Mock()
-    substrate.metadata_v15 = unittest.mock.Mock(
-        **{
-            "value.return_value": {
-                "apis": [
+
+    fake_runtime = MagicMock()
+    fake_metadata_v15 = MagicMock()
+    fake_metadata_v15.value.return_value = {
+        "apis": [
+            {
+                "name": "SubstrateApi",
+                "methods": [
                     {
-                        "name": "SubstrateApi",
-                        "methods": [
-                            {
-                                "name": "SubstrateMethod",
-                                "inputs": [],
-                                "output": "1",
-                            },
-                        ],
+                        "name": "SubstrateMethod",
+                        "inputs": [],
+                        "output": "1",
                     },
                 ],
             },
+        ],
+        "types": {
+            "types": [
+                {
+                    "id": "1",
+                    "type": {
+                        "path": ["Vec"],
+                        "def": {"sequence": {"type": "4"}},
+                    },
+                },
+            ]
+        },
+    }
+    fake_runtime.metadata_v15 = fake_metadata_v15
+    substrate.init_runtime = AsyncMock(return_value=fake_runtime)
+
+    # Patch encode_scale (should not be called in this test since no inputs)
+    substrate.encode_scale = AsyncMock()
+
+    # Patch decode_scale to produce a dummy value
+    substrate.decode_scale = AsyncMock(return_value="decoded_result")
+
+    # Patch RPC request with correct behavior
+    substrate.rpc_request = AsyncMock(
+        side_effect=lambda method, params: {
+            "result": "0x00" if method == "state_call" else {"parentHash": "0xDEADBEEF"}
         }
     )
-    substrate.rpc_request = unittest.mock.AsyncMock(
-        return_value={
-            "result": "0x00",
-        },
-    )
-    substrate.decode_scale = unittest.mock.AsyncMock()
 
+    # Patch get_block_runtime_info
+    substrate.get_block_runtime_info = AsyncMock(return_value={"specVersion": "1"})
+
+    # Run the call
     result = await substrate.runtime_call(
         "SubstrateApi",
         "SubstrateMethod",
     )
 
+    # Validate the result is wrapped in ScaleObj
     assert isinstance(result, ScaleObj)
-    assert result.value is substrate.decode_scale.return_value
+    assert result.value == "decoded_result"
 
-    substrate.rpc_request.assert_called_once_with(
-        "state_call",
-        ["SubstrateApi_SubstrateMethod", "", None],
-    )
+    # Check decode_scale called correctly
     substrate.decode_scale.assert_called_once_with("scale_info::1", b"\x00")
+
+    # encode_scale should not be called since no inputs
+    substrate.encode_scale.assert_not_called()
+
+    # Check RPC request called for the state_call
+    substrate.rpc_request.assert_any_call(
+        "state_call", ["SubstrateApi_SubstrateMethod", "", None]
+    )

--- a/tests/unit_tests/asyncio_/test_substrate_interface.py
+++ b/tests/unit_tests/asyncio_/test_substrate_interface.py
@@ -23,11 +23,7 @@ async def test_invalid_url_raises_exception():
 
 @pytest.mark.asyncio
 async def test_runtime_call(monkeypatch):
-    monkeypatch.setattr(
-        "async_substrate_interface.async_substrate.Websocket", unittest.mock.Mock()
-    )
-
-    substrate = AsyncSubstrateInterface("ws://localhost")
+    substrate = AsyncSubstrateInterface("ws://localhost", _mock=True)
     substrate._metadata = unittest.mock.Mock()
     substrate.metadata_v15 = unittest.mock.Mock(
         **{

--- a/tests/unit_tests/sync/test_substrate_interface.py
+++ b/tests/unit_tests/sync/test_substrate_interface.py
@@ -1,54 +1,74 @@
-import unittest.mock
+from unittest.mock import MagicMock
 
 from async_substrate_interface.sync_substrate import SubstrateInterface
 from async_substrate_interface.types import ScaleObj
 
 
 def test_runtime_call(monkeypatch):
-    monkeypatch.setattr(
-        "async_substrate_interface.sync_substrate.connect", unittest.mock.MagicMock()
-    )
-
-    substrate = SubstrateInterface(
-        "ws://localhost",
-        _mock=True,
-    )
-    substrate._metadata = unittest.mock.Mock()
-    substrate.metadata_v15 = unittest.mock.Mock(
-        **{
-            "value.return_value": {
-                "apis": [
+    substrate = SubstrateInterface("ws://localhost", _mock=True)
+    fake_runtime = MagicMock()
+    fake_metadata_v15 = MagicMock()
+    fake_metadata_v15.value.return_value = {
+        "apis": [
+            {
+                "name": "SubstrateApi",
+                "methods": [
                     {
-                        "name": "SubstrateApi",
-                        "methods": [
-                            {
-                                "name": "SubstrateMethod",
-                                "inputs": [],
-                                "output": "1",
-                            },
-                        ],
+                        "name": "SubstrateMethod",
+                        "inputs": [],
+                        "output": "1",
                     },
                 ],
             },
+        ],
+        "types": {
+            "types": [
+                {
+                    "id": "1",
+                    "type": {
+                        "path": ["Vec"],
+                        "def": {"sequence": {"type": "4"}},
+                    },
+                },
+            ]
+        },
+    }
+    fake_runtime.metadata_v15 = fake_metadata_v15
+    substrate.init_runtime = MagicMock(return_value=fake_runtime)
+
+    # Patch encode_scale (should not be called in this test since no inputs)
+    substrate.encode_scale = MagicMock()
+
+    # Patch decode_scale to produce a dummy value
+    substrate.decode_scale = MagicMock(return_value="decoded_result")
+
+    # Patch RPC request with correct behavior
+    substrate.rpc_request = MagicMock(
+        side_effect=lambda method, params: {
+            "result": "0x00" if method == "state_call" else {"parentHash": "0xDEADBEEF"}
         }
     )
-    substrate.rpc_request = unittest.mock.Mock(
-        return_value={
-            "result": "0x00",
-        },
-    )
-    substrate.decode_scale = unittest.mock.Mock()
 
+    # Patch get_block_runtime_info
+    substrate.get_block_runtime_info = MagicMock(return_value={"specVersion": "1"})
+
+    # Run the call
     result = substrate.runtime_call(
         "SubstrateApi",
         "SubstrateMethod",
     )
 
+    # Validate the result is wrapped in ScaleObj
     assert isinstance(result, ScaleObj)
-    assert result.value is substrate.decode_scale.return_value
+    assert result.value == "decoded_result"
 
-    substrate.rpc_request.assert_called_once_with(
-        "state_call",
-        ["SubstrateApi_SubstrateMethod", "", None],
-    )
+    # Check decode_scale called correctly
     substrate.decode_scale.assert_called_once_with("scale_info::1", b"\x00")
+
+    # encode_scale should not be called since no inputs
+    substrate.encode_scale.assert_not_called()
+
+    # Check RPC request called for the state_call
+    substrate.rpc_request.assert_any_call(
+        "state_call", ["SubstrateApi_SubstrateMethod", "", None]
+    )

--- a/tests/unit_tests/test_cache.py
+++ b/tests/unit_tests/test_cache.py
@@ -1,0 +1,83 @@
+import asyncio
+import pytest
+from unittest import mock
+
+from async_substrate_interface.utils.cache import CachedFetcher
+
+
+@pytest.mark.asyncio
+async def test_cached_fetcher_fetches_and_caches():
+    """Tests that CachedFetcher correctly fetches and caches results."""
+    # Setup
+    mock_method = mock.AsyncMock(side_effect=lambda x: f"result_{x}")
+    fetcher = CachedFetcher(max_size=2, method=mock_method)
+
+    # First call should trigger the method
+    result1 = await fetcher.execute("key1")
+    assert result1 == "result_key1"
+    mock_method.assert_awaited_once_with("key1")
+
+    # Second call with the same key should use the cache
+    result2 = await fetcher.execute("key1")
+    assert result2 == "result_key1"
+    # Ensure the method was NOT called again
+    assert mock_method.await_count == 1
+
+    # Third call with a new key triggers a method call
+    result3 = await fetcher.execute("key2")
+    assert result3 == "result_key2"
+    assert mock_method.await_count == 2
+
+@pytest.mark.asyncio
+async def test_cached_fetcher_handles_inflight_requests():
+    """Tests that CachedFetcher waits for in-flight results instead of re-fetching."""
+    # Create an event to control when the mock returns
+    event = asyncio.Event()
+
+    async def slow_method(x):
+        await event.wait()
+        return f"slow_result_{x}"
+
+    fetcher = CachedFetcher(max_size=2, method=slow_method)
+
+    # Start first request
+    task1 = asyncio.create_task(fetcher.execute("key1"))
+    await asyncio.sleep(0.1)  # Let the task start and be inflight
+
+    # Second request for the same key while the first is in-flight
+    task2 = asyncio.create_task(fetcher.execute("key1"))
+    await asyncio.sleep(0.1)
+
+    # Release the inflight request
+    event.set()
+    result1, result2 = await asyncio.gather(task1, task2)
+    assert result1 == result2 == "slow_result_key1"
+
+@pytest.mark.asyncio
+async def test_cached_fetcher_propagates_errors():
+    """Tests that CachedFetcher correctly propagates errors."""
+    async def error_method(x):
+        raise ValueError("Boom!")
+
+    fetcher = CachedFetcher(max_size=2, method=error_method)
+
+    with pytest.raises(ValueError, match="Boom!"):
+        await fetcher.execute("key1")
+
+@pytest.mark.asyncio
+async def test_cached_fetcher_eviction():
+    """Tests that LRU eviction works in CachedFetcher."""
+    mock_method = mock.AsyncMock(side_effect=lambda x: f"val_{x}")
+    fetcher = CachedFetcher(max_size=2, method=mock_method)
+
+    # Fill cache
+    await fetcher.execute("key1")
+    await fetcher.execute("key2")
+    assert list(fetcher._cache.cache.keys()) == list(fetcher._cache.cache.keys())
+
+    # Insert a new key to trigger eviction
+    await fetcher.execute("key3")
+    # key1 should be evicted
+    assert "key1" not in fetcher._cache.cache
+    assert "key2" in fetcher._cache.cache
+    assert "key3" in fetcher._cache.cache

--- a/tests/unit_tests/test_cache.py
+++ b/tests/unit_tests/test_cache.py
@@ -28,6 +28,7 @@ async def test_cached_fetcher_fetches_and_caches():
     assert result3 == "result_key2"
     assert mock_method.await_count == 2
 
+
 @pytest.mark.asyncio
 async def test_cached_fetcher_handles_inflight_requests():
     """Tests that CachedFetcher waits for in-flight results instead of re-fetching."""
@@ -53,9 +54,11 @@ async def test_cached_fetcher_handles_inflight_requests():
     result1, result2 = await asyncio.gather(task1, task2)
     assert result1 == result2 == "slow_result_key1"
 
+
 @pytest.mark.asyncio
 async def test_cached_fetcher_propagates_errors():
     """Tests that CachedFetcher correctly propagates errors."""
+
     async def error_method(x):
         raise ValueError("Boom!")
 
@@ -63,6 +66,7 @@ async def test_cached_fetcher_propagates_errors():
 
     with pytest.raises(ValueError, match="Boom!"):
         await fetcher.execute("key1")
+
 
 @pytest.mark.asyncio
 async def test_cached_fetcher_eviction():


### PR DESCRIPTION
Fixes potential edge cases:

- Websocket reporting initialised without being initialised (Issue #95)
- Starting a new loop to get loop time
- Cache issues with async cache.
- Ensure websocket IDs cannot be used twice while still in use
- Adjust sleep wait period when item is not retrievable yet.
- Fixes tests
- Adds a test runner GH workflow