### PR TITLE
Stop iteration fix

### DIFF
--- a/async_substrate_interface/substrate_addons.py
+++ b/async_substrate_interface/substrate_addons.py
@@ -355,7 +355,7 @@ class RetryAsyncSubstrate(AsyncSubstrateInterface):
             try:
                 await self._reinstantiate_substrate(e, use_archive=use_archive)
                 return await method_(*args, **kwargs)
-            except StopAsyncIteration:
+            except StopIteration:
                 logger.error(
                     f"Max retries exceeded with {self.url}. No more fallback chains."
                 )


### PR DESCRIPTION
StopAsyncIteration should be StopIteration, as it's iterating over the chain endpoints, not async iterating.