### PR TITLE
async websocket stability

### DIFF
--- a/async_substrate_interface/substrate_addons.py
+++ b/async_substrate_interface/substrate_addons.py
@@ -264,6 +264,7 @@ class RetryAsyncSubstrate(AsyncSubstrateInterface):
         _mock: bool = False,
         _log_raw_websockets: bool = False,
         archive_nodes: Optional[list[str]] = None,
+        ws_shutdown_timer: float = 5.0,
     ):
         fallback_chains = fallback_chains or []
         archive_nodes = archive_nodes or []
@@ -291,6 +292,7 @@ class RetryAsyncSubstrate(AsyncSubstrateInterface):
             retry_timeout=retry_timeout,
             max_retries=max_retries,
             _log_raw_websockets=_log_raw_websockets,
+            ws_shutdown_timer=ws_shutdown_timer,
         )
         self._original_methods = {
             method: getattr(self, method) for method in RETRY_METHODS

--- a/tests/unit_tests/asyncio_/test_substrate_interface.py
+++ b/tests/unit_tests/asyncio_/test_substrate_interface.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -91,3 +92,22 @@ async def test_runtime_call(monkeypatch):
     substrate.rpc_request.assert_any_call(
         "state_call", ["SubstrateApi_SubstrateMethod", "", None]
     )
+
+
+@pytest.mark.asyncio
+async def test_websocket_shutdown_timer():
+    # using default ws shutdown timer of 5.0 seconds
+    async with AsyncSubstrateInterface("wss://lite.sub.latent.to:443") as substrate:
+        await substrate.get_chain_head()
+        await asyncio.sleep(6)
+        assert (
+            substrate.ws._initialized is False
+        )  # connection should have closed automatically
+
+    # using custom ws shutdown timer of 10.0 seconds
+    async with AsyncSubstrateInterface(
+        "wss://lite.sub.latent.to:443", ws_shutdown_timer=10.0
+    ) as substrate:
+        await substrate.get_chain_head()
+        await asyncio.sleep(6)  # same sleep time as before
+        assert substrate.ws._initialized is True  # connection should still be open


### PR DESCRIPTION
- Catch errors better
- Stop overusing `asyncio.Lock` in conflicting environments
- Expose websocket shutdown timer to be user-configurable as it was supposed to be initially