### PR TITLE
Improve CachedFetcher

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -60,7 +60,6 @@ from async_substrate_interface.utils import (
 )
 from async_substrate_interface.utils.cache import (
     async_sql_lru_cache,
-    CachedFetcher,
     cached_fetcher,
 )
 from async_substrate_interface.utils.decoding import (

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -1059,6 +1059,15 @@ class AsyncSubstrateInterface(SubstrateMixin):
     async def get_runtime_for_version(
         self, runtime_version: int, block_hash: Optional[str] = None
     ) -> Runtime:
+        """
+        Retrieves the `Runtime` for a given runtime version at a given block hash.
+        Args:
+            runtime_version: version of the runtime (from `get_block_runtime_version_for`)
+            block_hash: hash of the block to query
+
+        Returns:
+            Runtime object for the given runtime version
+        """
         return await self._get_runtime_for_version(runtime_version, block_hash)
 
     async def _get_runtime_for_version(
@@ -1927,10 +1936,18 @@ class AsyncSubstrateInterface(SubstrateMixin):
         return runtime.metadata_v15
 
     @cached_fetcher(max_size=512)
-    async def get_parent_block_hash(self, block_hash):
+    async def get_parent_block_hash(self, block_hash) -> str:
+        """
+        Retrieves the block hash of the parent of the given block hash
+        Args:
+            block_hash: hash of the block to query
+
+        Returns:
+            Hash of the parent block hash, or the original block hash (if it has not parent)
+        """
         return await self._get_parent_block_hash(block_hash)
 
-    async def _get_parent_block_hash(self, block_hash):
+    async def _get_parent_block_hash(self, block_hash) -> str:
         block_header = await self.rpc_request("chain_getHeader", [block_hash])
 
         if block_header["result"] is None:
@@ -1975,25 +1992,25 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
     @cached_fetcher(max_size=16)
     async def get_block_runtime_info(self, block_hash: str) -> dict:
+        """
+        Retrieve the runtime info of given block_hash
+        """
         return await self._get_block_runtime_info(block_hash)
 
     get_block_runtime_version = get_block_runtime_info
 
     async def _get_block_runtime_info(self, block_hash: str) -> dict:
-        """
-        Retrieve the runtime info of given block_hash
-        """
         response = await self.rpc_request("state_getRuntimeVersion", [block_hash])
         return response.get("result")
 
     @cached_fetcher(max_size=512)
     async def get_block_runtime_version_for(self, block_hash: str):
-        return await self._get_block_runtime_version_for(block_hash)
-
-    async def _get_block_runtime_version_for(self, block_hash: str):
         """
         Retrieve the runtime version of the parent of a given block_hash
         """
+        return await self._get_block_runtime_version_for(block_hash)
+
+    async def _get_block_runtime_version_for(self, block_hash: str):
         parent_block_hash = await self.get_parent_block_hash(block_hash)
         runtime_info = await self.get_block_runtime_info(parent_block_hash)
         if runtime_info is None:
@@ -2306,6 +2323,14 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
     @cached_fetcher(max_size=512)
     async def get_block_hash(self, block_id: int) -> str:
+        """
+        Retrieves the hash of the specified block number
+        Args:
+            block_id: block number
+
+        Returns:
+            Hash of the block
+        """
         return await self._get_block_hash(block_id)
 
     async def _get_block_hash(self, block_id: int) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ keywords = ["substrate", "development", "bittensor"]
 
 dependencies = [
   "wheel",
-  "asyncstdlib~=3.13.0",
   "bt-decode==v0.6.0",
   "scalecodec~=1.2.11",
   "websockets>=14.1",

--- a/tests/unit_tests/test_cache.py
+++ b/tests/unit_tests/test_cache.py
@@ -13,18 +13,18 @@ async def test_cached_fetcher_fetches_and_caches():
     fetcher = CachedFetcher(max_size=2, method=mock_method)
 
     # First call should trigger the method
-    result1 = await fetcher.execute("key1")
+    result1 = await fetcher("key1")
     assert result1 == "result_key1"
     mock_method.assert_awaited_once_with("key1")
 
     # Second call with the same key should use the cache
-    result2 = await fetcher.execute("key1")
+    result2 = await fetcher("key1")
     assert result2 == "result_key1"
     # Ensure the method was NOT called again
     assert mock_method.await_count == 1
 
     # Third call with a new key triggers a method call
-    result3 = await fetcher.execute("key2")
+    result3 = await fetcher("key2")
     assert result3 == "result_key2"
     assert mock_method.await_count == 2
 
@@ -42,11 +42,11 @@ async def test_cached_fetcher_handles_inflight_requests():
     fetcher = CachedFetcher(max_size=2, method=slow_method)
 
     # Start first request
-    task1 = asyncio.create_task(fetcher.execute("key1"))
+    task1 = asyncio.create_task(fetcher("key1"))
     await asyncio.sleep(0.1)  # Let the task start and be inflight
 
     # Second request for the same key while the first is in-flight
-    task2 = asyncio.create_task(fetcher.execute("key1"))
+    task2 = asyncio.create_task(fetcher("key1"))
     await asyncio.sleep(0.1)
 
     # Release the inflight request
@@ -65,7 +65,7 @@ async def test_cached_fetcher_propagates_errors():
     fetcher = CachedFetcher(max_size=2, method=error_method)
 
     with pytest.raises(ValueError, match="Boom!"):
-        await fetcher.execute("key1")
+        await fetcher("key1")
 
 
 @pytest.mark.asyncio
@@ -75,12 +75,12 @@ async def test_cached_fetcher_eviction():
     fetcher = CachedFetcher(max_size=2, method=mock_method)
 
     # Fill cache
-    await fetcher.execute("key1")
-    await fetcher.execute("key2")
+    await fetcher("key1")
+    await fetcher("key2")
     assert list(fetcher._cache.cache.keys()) == list(fetcher._cache.cache.keys())
 
     # Insert a new key to trigger eviction
-    await fetcher.execute("key3")
+    await fetcher("key3")
     # key1 should be evicted
     assert "key1" not in fetcher._cache.cache
     assert "key2" in fetcher._cache.cache


### PR DESCRIPTION
- Makes `CachedFetcher` compatible with a wrapper
- Allow `CachedFetcher` to handle methods with multiple args.
- Adds a wrapper for using `CachedFetcher` as you would any other cache (i.e. `@functools.cached`
- Replaces `asyncstdlib.lru_cache` with `CachedFetcher` in `DiskCachedAsyncSubstrate`
- Removes `asyncstdlib` as a dependency
- Fixes tests
- Replaces `cache.py`'s `print` calls with `logging`.
- Adds new method `get_runtime_for_version` which is basically the internals for fetching/creating a `Runtime` object from `init_runtime`, but which can be cached by runtime version specified.