### PR TITLE
Only use Runtime objects in AsyncSubstrateInterface

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -841,6 +841,21 @@ class AsyncSubstrateInterface(SubstrateMixin):
             return runtime.metadata
 
     @property
+    def implements_scaleinfo(self) -> Optional[bool]:
+        """
+        Returns True if current runtime implementation a `PortableRegistry` (`MetadataV14` and higher)
+
+        Returns
+        -------
+        bool
+        """
+        runtime = self.runtime_cache.last_used
+        if runtime is not None:
+            return runtime.implements_scaleinfo
+        else:
+            return None
+
+    @property
     async def properties(self):
         if self._properties is None:
             self._properties = (await self.rpc_request("system_properties", [])).get(

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -843,11 +843,8 @@ class AsyncSubstrateInterface(SubstrateMixin):
     @property
     def implements_scaleinfo(self) -> Optional[bool]:
         """
-        Returns True if current runtime implementation a `PortableRegistry` (`MetadataV14` and higher)
-
-        Returns
-        -------
-        bool
+        Returns True if most-recently-used runtime implements a `PortableRegistry` (`MetadataV14` and higher). Returns
+        `None` if no runtime has been loaded.
         """
         runtime = self.runtime_cache.last_used
         if runtime is not None:

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -2376,10 +2376,10 @@ class AsyncSubstrateInterface(SubstrateMixin):
         if call_params is None:
             call_params = {}
 
-        await self.init_runtime(block_hash=block_hash)
+        runtime = await self.init_runtime(block_hash=block_hash)
 
-        call = self.runtime_config.create_scale_object(
-            type_string="Call", metadata=self.runtime.metadata
+        call = runtime.runtime_config.create_scale_object(
+            type_string="Call", metadata=runtime.metadata
         )
 
         call.encode(

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -824,6 +824,23 @@ class AsyncSubstrateInterface(SubstrateMixin):
         pass
 
     @property
+    def metadata(self):
+        warnings.warn(
+            "Calling AsyncSubstrateInterface.metadata is deprecated, as metadata is runtime-dependent, and it"
+            "can be unclear which for runtime you seek the metadata. You should instead use the specific runtime's "
+            "metadata. For now, the most recently used runtime will be given.",
+            category=DeprecationWarning,
+        )
+        runtime = self.runtime_cache.last_used
+        if not runtime or runtime.metadata is None:
+            raise AttributeError(
+                "Metadata not found. This generally indicates that the AsyncSubstrateInterface object "
+                "is not properly async initialized."
+            )
+        else:
+            return runtime.metadata
+
+    @property
     async def properties(self):
         if self._properties is None:
             self._properties = (await self.rpc_request("system_properties", [])).get(

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -34,7 +34,6 @@ from scalecodec.types import (
 from websockets.asyncio.client import connect
 from websockets.exceptions import ConnectionClosed, WebSocketException
 
-from async_substrate_interface.const import SS58_FORMAT
 from async_substrate_interface.errors import (
     SubstrateRequestException,
     ExtrinsicNotFound,
@@ -989,7 +988,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
             return None
         if type_string == "scale_info::0":  # Is an AccountId
             # Decode AccountId bytes to SS58 address
-            return ss58_encode(scale_bytes, SS58_FORMAT)
+            return ss58_encode(scale_bytes, self.ss58_format)
         else:
             if not runtime:
                 runtime = await self.init_runtime(block_hash=block_hash)
@@ -1911,11 +1910,16 @@ class AsyncSubstrateInterface(SubstrateMixin):
             attributes = attributes_data
             if isinstance(attributes, dict):
                 for key, value in attributes.items():
+                    if key == "who":
+                        who = ss58_encode(bytes(value[0]), self.ss58_format)
+                        attributes["who"] = who
                     if isinstance(value, dict):
                         # Convert nested single-key dictionaries to their keys as strings
-                        sub_key = next(iter(value.keys()))
-                        if value[sub_key] == ():
-                            attributes[key] = sub_key
+                        for sub_key, sub_value in value.items():
+                            if isinstance(sub_value, dict):
+                                for sub_sub_key, sub_sub_value in sub_value.items():
+                                    if sub_sub_value == ():
+                                        attributes[key][sub_key] = sub_sub_key
 
             # Create the converted dictionary
             converted = {

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -1361,9 +1361,9 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
     async def get_metadata_error(
         self,
-        module_name,
-        error_name,
-        block_hash=None,
+        module_name: str,
+        error_name: str,
+        block_hash: Optional[str] = None,
         runtime: Optional[Runtime] = None,
     ):
         """
@@ -3096,9 +3096,9 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
     async def get_metadata_constant(
         self,
-        module_name,
-        constant_name,
-        block_hash=None,
+        module_name: str,
+        constant_name: str,
+        block_hash: Optional[str] = None,
         runtime: Optional[Runtime] = None,
     ):
         """

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -755,7 +755,9 @@ class AsyncSubstrateInterface(SubstrateMixin):
             ws_shutdown_timer: how long after the last connection your websocket should close
 
         """
-        super().__init__(type_registry, type_registry_preset, use_remote_preset)
+        super().__init__(
+            type_registry, type_registry_preset, use_remote_preset, ss58_format
+        )
         self.max_retries = max_retries
         self.retry_timeout = retry_timeout
         self.chain_endpoint = url
@@ -784,7 +786,6 @@ class AsyncSubstrateInterface(SubstrateMixin):
         }
         self.initialized = False
         self._forgettable_task = None
-        self.ss58_format = ss58_format
         self.type_registry = type_registry
         self.type_registry_preset = type_registry_preset
         self.runtime_cache = RuntimeCache()
@@ -1057,10 +1058,12 @@ class AsyncSubstrateInterface(SubstrateMixin):
         logger.debug(
             f"Retrieved metadata and metadata v15 for {runtime_version} from Substrate node"
         )
-
+        implements_scale_info = metadata.portable_registry is not None
         runtime = Runtime(
             chain=self.chain,
-            runtime_config=self.runtime_config,
+            runtime_config=self._runtime_config_copy(
+                implements_scale_info=implements_scale_info
+            ),
             metadata=metadata,
             type_registry=self.type_registry,
             metadata_v15=metadata_v15,

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -1033,9 +1033,17 @@ class AsyncSubstrateInterface(SubstrateMixin):
     async def _get_runtime_for_version(
         self, runtime_version: int, block_hash: Optional[str] = None
     ) -> Runtime:
-        runtime_block_hash, block_number = await asyncio.gather(
-            self.get_parent_block_hash(block_hash), self.get_block_number(block_hash)
-        )
+        if not block_hash:
+            block_hash, runtime_block_hash, block_number = await asyncio.gather(
+                self.get_chain_head(),
+                self.get_parent_block_hash(block_hash),
+                self.get_block_number(block_hash),
+            )
+        else:
+            runtime_block_hash, block_number = await asyncio.gather(
+                self.get_parent_block_hash(block_hash),
+                self.get_block_number(block_hash),
+            )
         runtime_info, metadata, (metadata_v15, registry) = await asyncio.gather(
             self.get_block_runtime_info(runtime_block_hash),
             self.get_block_metadata(block_hash=runtime_block_hash, decode=True),

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -755,7 +755,8 @@ class SubstrateInterface(SubstrateMixin):
             self.runtime = runtime
             return runtime
         else:
-            return self.get_runtime_for_version(runtime_version, block_hash)
+            self.runtime = self.get_runtime_for_version(runtime_version, block_hash)
+            return self.runtime
 
     def get_runtime_for_version(
         self, runtime_version: int, block_hash: Optional[str] = None
@@ -2524,13 +2525,13 @@ class SubstrateInterface(SubstrateMixin):
         for idx, param in enumerate(runtime_call_def["inputs"]):
             param_type_string = f"scale_info::{param['ty']}"
             if isinstance(params, list):
-                param_data += self.encode_scale(param_type_string, params[idx])
+                param_data += self.encode_scale(param_type_string, params[idx], runtime=runtime)
             else:
                 if param["name"] not in params:
                     raise ValueError(f"Runtime Call param '{param['name']}' is missing")
 
                 param_data += self.encode_scale(
-                    param_type_string, params[param["name"]]
+                    param_type_string, params[param["name"]], runtime=runtime
                 )
 
         # RPC request

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -577,6 +577,20 @@ class SubstrateInterface(SubstrateMixin):
             return self.runtime.metadata
 
     @property
+    def implements_scaleinfo(self) -> Optional[bool]:
+        """
+        Returns True if current runtime implementation a `PortableRegistry` (`MetadataV14` and higher)
+
+        Returns
+        -------
+        bool
+        """
+        if self.runtime and self.runtime.metadata:
+            return self.runtime.metadata.portable_registry is not None
+        else:
+            return None
+
+    @property
     def properties(self):
         if self._properties is None:
             self._properties = self.rpc_request("system_properties", []).get("result")

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -560,7 +560,7 @@ class SubstrateInterface(SubstrateMixin):
                     "System", "SS58Prefix", block_hash=self.last_block_hash
                 )
                 if ss58_prefix_constant:
-                    self.ss58_format = ss58_prefix_constant
+                    self.ss58_format = ss58_prefix_constant.value
         self.initialized = True
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -506,6 +506,7 @@ class SubstrateInterface(SubstrateMixin):
             _log_raw_websockets: whether to log raw websocket requests during RPC requests
 
         """
+        super().__init__(type_registry, type_registry_preset, use_remote_preset)
         self.max_retries = max_retries
         self.retry_timeout = retry_timeout
         self.chain_endpoint = url
@@ -526,9 +527,6 @@ class SubstrateInterface(SubstrateMixin):
             ss58_format=self.ss58_format, implements_scale_info=True
         )
         self.metadata_version_hex = "0x0f000000"  # v15
-        self.reload_type_registry()
-        self.registry_type_map = {}
-        self.type_id_to_name = {}
         self._mock = _mock
         self.log_raw_websockets = _log_raw_websockets
         if not _mock:

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -579,11 +579,8 @@ class SubstrateInterface(SubstrateMixin):
     @property
     def implements_scaleinfo(self) -> Optional[bool]:
         """
-        Returns True if current runtime implementation a `PortableRegistry` (`MetadataV14` and higher)
-
-        Returns
-        -------
-        bool
+        Returns True if current runtime implements a `PortableRegistry` (`MetadataV14` and higher). Returns `None` if
+        no currently loaded runtime.
         """
         if self.runtime and self.runtime.metadata:
             return self.runtime.metadata.portable_registry is not None

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -567,6 +567,16 @@ class SubstrateInterface(SubstrateMixin):
         self.ws.close()
 
     @property
+    def metadata(self):
+        if not self.runtime or self.runtime.metadata is None:
+            raise AttributeError(
+                "Metadata not found. This generally indicates that the AsyncSubstrateInterface object "
+                "is not properly async initialized."
+            )
+        else:
+            return self.runtime.metadata
+
+    @property
     def properties(self):
         if self._properties is None:
             self._properties = self.rpc_request("system_properties", []).get("result")

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -645,8 +645,8 @@ class SubstrateMixin(ABC):
     def serialize_storage_item(
         self,
         storage_item: ScaleType,
-        module,
-        spec_version_id,
+        module: str,
+        spec_version_id: int,
         runtime: Optional[Runtime] = None,
     ) -> dict:
         """

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -565,20 +565,6 @@ class SubstrateMixin(ABC):
         """
         return self._chain
 
-    @property
-    def implements_scaleinfo(self) -> Optional[bool]:
-        """
-        Returns True if current runtime implementation a `PortableRegistry` (`MetadataV14` and higher)
-
-        Returns
-        -------
-        bool
-        """
-        if self.runtime and self.runtime.metadata:
-            return self.runtime.metadata.portable_registry is not None
-        else:
-            return None
-
     def ss58_encode(
         self, public_key: Union[str, bytes], ss58_format: int = None
     ) -> str:
@@ -912,9 +898,7 @@ class SubstrateMixin(ABC):
                 else:
                     value = value.value  # Unwrap the value of the type
 
-            result = bytes(
-                encode_by_type_string(type_string, self.runtime.registry, value)
-            )
+            result = bytes(encode_by_type_string(type_string, runtime.registry, value))
         return result
 
     @staticmethod

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -15,7 +15,6 @@ from scalecodec.types import GenericCall, ScaleType, MultiAccountId
 from .const import SS58_FORMAT
 from .utils import json
 
-
 logger = logging.getLogger("async_substrate_interface")
 
 
@@ -69,6 +68,8 @@ class Runtime:
     runtime_info = None
     type_registry_preset = None
     registry: Optional[PortableRegistry] = None
+    registry_type_map: dict[str, int]
+    type_id_to_name: dict[int, str]
 
     def __init__(
         self,
@@ -90,6 +91,8 @@ class Runtime:
         self.registry = registry
         self.runtime_version = runtime_info.get("specVersion")
         self.transaction_version = runtime_info.get("transactionVersion")
+        if registry is not None:
+            self._load_registry_type_map(registry)
 
     @property
     def implements_scaleinfo(self) -> Optional[bool]:
@@ -108,93 +111,188 @@ class Runtime:
     def __str__(self):
         return f"Runtime: {self.chain} | {self.config}"
 
+    def reload_type_registry(
+        self, use_remote_preset: bool = True, auto_discover: bool = True
+    ):
+        """
+        Reload type registry and preset used to instantiate the SubstrateInterface object. Useful to periodically apply
+        changes in type definitions when a runtime upgrade occurred
 
-#    @property
-#    def implements_scaleinfo(self) -> bool:
-#        """
-#        Returns True if current runtime implementation a `PortableRegistry` (`MetadataV14` and higher)
-#        """
-#        if self.metadata:
-#            return self.metadata.portable_registry is not None
-#        else:
-#            return False
-#
-#    def reload_type_registry(
-#        self, use_remote_preset: bool = True, auto_discover: bool = True
-#    ):
-#        """
-#        Reload type registry and preset used to instantiate the SubstrateInterface object. Useful to periodically apply
-#        changes in type definitions when a runtime upgrade occurred
-#
-#        Args:
-#            use_remote_preset: When True preset is downloaded from Github master, otherwise use files from local
-#                installed scalecodec package
-#            auto_discover: Whether to automatically discover the type registry presets based on the chain name and the
-#                type registry
-#        """
-#        self.runtime_config.clear_type_registry()
-#
-#        self.runtime_config.implements_scale_info = self.implements_scaleinfo
-#
-#        # Load metadata types in runtime configuration
-#        self.runtime_config.update_type_registry(load_type_registry_preset(name="core"))
-#        self.apply_type_registry_presets(
-#            use_remote_preset=use_remote_preset, auto_discover=auto_discover
-#        )
-#
-#    def apply_type_registry_presets(
-#        self,
-#        use_remote_preset: bool = True,
-#        auto_discover: bool = True,
-#    ):
-#        """
-#        Applies type registry presets to the runtime
-#
-#        Args:
-#            use_remote_preset: whether to use presets from remote
-#            auto_discover: whether to use presets from local installed scalecodec package
-#        """
-#        if self.type_registry_preset is not None:
-#            # Load type registry according to preset
-#            type_registry_preset_dict = load_type_registry_preset(
-#                name=self.type_registry_preset, use_remote_preset=use_remote_preset
-#            )
-#
-#            if not type_registry_preset_dict:
-#                raise ValueError(
-#                    f"Type registry preset '{self.type_registry_preset}' not found"
-#                )
-#
-#        elif auto_discover:
-#            # Try to auto discover type registry preset by chain name
-#            type_registry_name = self.chain.lower().replace(" ", "-")
-#            try:
-#                type_registry_preset_dict = load_type_registry_preset(
-#                    type_registry_name
-#                )
-#                self.type_registry_preset = type_registry_name
-#            except ValueError:
-#                type_registry_preset_dict = None
-#
-#        else:
-#            type_registry_preset_dict = None
-#
-#        if type_registry_preset_dict:
-#            # Load type registries in runtime configuration
-#            if self.implements_scaleinfo is False:
-#                # Only runtime with no embedded types in metadata need the default set of explicit defined types
-#                self.runtime_config.update_type_registry(
-#                    load_type_registry_preset(
-#                        "legacy", use_remote_preset=use_remote_preset
-#                    )
-#                )
-#
-#            if self.type_registry_preset != "legacy":
-#                self.runtime_config.update_type_registry(type_registry_preset_dict)
-#
-#        if self.type_registry:
-#            # Load type registries in runtime configuration
-#            self.runtime_config.update_type_registry(self.type_registry)
+        Args:
+           use_remote_preset: When True preset is downloaded from Github master, otherwise use files from local
+               installed scalecodec package
+           auto_discover: Whether to automatically discover the type registry presets based on the chain name and the
+               type registry
+        """
+        self.runtime_config.clear_type_registry()
+
+        self.runtime_config.implements_scale_info = self.implements_scaleinfo
+
+        # Load metadata types in runtime configuration
+        self.runtime_config.update_type_registry(load_type_registry_preset(name="core"))
+        self.apply_type_registry_presets(
+            use_remote_preset=use_remote_preset, auto_discover=auto_discover
+        )
+
+    def apply_type_registry_presets(
+        self,
+        use_remote_preset: bool = True,
+        auto_discover: bool = True,
+    ):
+        """
+        Applies type registry presets to the runtime
+
+        Args:
+           use_remote_preset: whether to use presets from remote
+           auto_discover: whether to use presets from local installed scalecodec package
+        """
+        if self.type_registry_preset is not None:
+            # Load type registry according to preset
+            type_registry_preset_dict = load_type_registry_preset(
+                name=self.type_registry_preset, use_remote_preset=use_remote_preset
+            )
+
+            if not type_registry_preset_dict:
+                raise ValueError(
+                    f"Type registry preset '{self.type_registry_preset}' not found"
+                )
+
+        elif auto_discover:
+            # Try to auto discover type registry preset by chain name
+            type_registry_name = self.chain.lower().replace(" ", "-")
+            try:
+                type_registry_preset_dict = load_type_registry_preset(
+                    type_registry_name
+                )
+                self.type_registry_preset = type_registry_name
+            except ValueError:
+                type_registry_preset_dict = None
+
+        else:
+            type_registry_preset_dict = None
+
+        if type_registry_preset_dict:
+            # Load type registries in runtime configuration
+            if self.implements_scaleinfo is False:
+                # Only runtime with no embedded types in metadata need the default set of explicit defined types
+                self.runtime_config.update_type_registry(
+                    load_type_registry_preset(
+                        "legacy", use_remote_preset=use_remote_preset
+                    )
+                )
+
+            if self.type_registry_preset != "legacy":
+                self.runtime_config.update_type_registry(type_registry_preset_dict)
+
+        if self.type_registry:
+            # Load type registries in runtime configuration
+            self.runtime_config.update_type_registry(self.type_registry)
+
+    def _load_registry_type_map(self, registry):
+        registry_type_map = {}
+        type_id_to_name = {}
+        types = json.loads(registry.registry)["types"]
+        type_by_id = {entry["id"]: entry for entry in types}
+
+        # Pass 1: Gather simple types
+        for type_entry in types:
+            type_id = type_entry["id"]
+            type_def = type_entry["type"]["def"]
+            type_path = type_entry["type"].get("path")
+            if type_entry.get("params") or "variant" in type_def:
+                continue
+            if type_path:
+                type_name = type_path[-1]
+                registry_type_map[type_name] = type_id
+                type_id_to_name[type_id] = type_name
+            else:
+                # Possibly a primitive
+                if "primitive" in type_def:
+                    prim_name = type_def["primitive"]
+                    registry_type_map[prim_name] = type_id
+                    type_id_to_name[type_id] = prim_name
+
+        # Pass 2: Resolve remaining types
+        pending_ids = set(type_by_id.keys()) - set(type_id_to_name.keys())
+
+        def resolve_type_definition(type_id_):
+            type_entry_ = type_by_id[type_id_]
+            type_def_ = type_entry_["type"]["def"]
+            type_path_ = type_entry_["type"].get("path", [])
+            type_params = type_entry_["type"].get("params", [])
+
+            if type_id_ in type_id_to_name:
+                return type_id_to_name[type_id_]
+
+            # Resolve complex types with paths (including generics like Option etc)
+            if type_path_:
+                type_name_ = type_path_[-1]
+                if type_params:
+                    inner_names = []
+                    for param in type_params:
+                        dep_id = param["type"]
+                        if dep_id not in type_id_to_name:
+                            return None
+                        inner_names.append(type_id_to_name[dep_id])
+                    return f"{type_name_}<{', '.join(inner_names)}>"
+                if "variant" in type_def_:
+                    return None
+                return type_name_
+
+            elif "sequence" in type_def_:
+                sequence_type_id = type_def_["sequence"]["type"]
+                inner_type = type_id_to_name.get(sequence_type_id)
+                if inner_type:
+                    type_name_ = f"Vec<{inner_type}>"
+                    return type_name_
+
+            elif "array" in type_def_:
+                array_type_id = type_def_["array"]["type"]
+                inner_type = type_id_to_name.get(array_type_id)
+                maybe_len = type_def_["array"].get("len")
+                if inner_type:
+                    if maybe_len:
+                        type_name_ = f"[{inner_type}; {maybe_len}]"
+                    else:
+                        type_name_ = f"[{inner_type}]"
+                    return type_name_
+
+            elif "compact" in type_def_:
+                compact_type_id = type_def_["compact"]["type"]
+                inner_type = type_id_to_name.get(compact_type_id)
+                if inner_type:
+                    type_name_ = f"Compact<{inner_type}>"
+                    return type_name_
+
+            elif "tuple" in type_def_:
+                tuple_type_ids = type_def_["tuple"]
+                type_names = []
+                for inner_type_id in tuple_type_ids:
+                    if inner_type_id not in type_id_to_name:
+                        return None
+                    type_names.append(type_id_to_name[inner_type_id])
+                type_name_ = ", ".join(type_names)
+                type_name_ = f"({type_name_})"
+                return type_name_
+
+            elif "variant" in type_def_:
+                return None
+
+            return None
+
+        resolved_type = True
+        while resolved_type and pending_ids:
+            resolved_type = False
+            for type_id in list(pending_ids):
+                name = resolve_type_definition(type_id)
+                if name is not None:
+                    type_id_to_name[type_id] = name
+                    registry_type_map[name] = type_id
+                    pending_ids.remove(type_id)
+                    resolved_type = True
+
+        self.registry_type_map = registry_type_map
+        self.type_id_to_name = type_id_to_name
 
 
 class RequestManager:
@@ -387,8 +485,6 @@ class SubstrateMixin(ABC):
     type_registry: Optional[dict]
     ss58_format: Optional[int]
     ws_max_size = 2**32
-    registry_type_map: dict[str, int]
-    type_id_to_name: dict[int, str]
     runtime: Runtime = None
 
     @property
@@ -468,7 +564,11 @@ class SubstrateMixin(ABC):
         return is_valid_ss58_address(value, valid_ss58_format=self.ss58_format)
 
     def serialize_storage_item(
-        self, storage_item: ScaleType, module, spec_version_id
+        self,
+        storage_item: ScaleType,
+        module,
+        spec_version_id,
+        runtime: Optional[Runtime] = None,
     ) -> dict:
         """
         Helper function to serialize a storage item
@@ -477,10 +577,17 @@ class SubstrateMixin(ABC):
             storage_item: the storage item to serialize
             module: the module to use to serialize the storage item
             spec_version_id: the version id
+            runtime: The runtime to serialize the storage item
 
         Returns:
             dict
         """
+        if not runtime:
+            runtime = self.runtime
+            metadata = self.metadata
+        else:
+            metadata = runtime.metadata
+
         storage_dict = {
             "storage_name": storage_item.name,
             "storage_modifier": storage_item.modifier,
@@ -511,10 +618,10 @@ class SubstrateMixin(ABC):
             query_value = storage_item.value_object["default"].value_object
 
         try:
-            obj = self.runtime_config.create_scale_object(
+            obj = runtime.runtime_config.create_scale_object(
                 type_string=value_scale_type,
                 data=ScaleBytes(query_value),
-                metadata=self.metadata,
+                metadata=metadata,
             )
             obj.decode()
             storage_dict["storage_default"] = obj.decode()
@@ -636,183 +743,6 @@ class SubstrateMixin(ABC):
             "spec_version": spec_version,
         }
 
-    def _load_registry_type_map(self, registry):
-        registry_type_map = {}
-        type_id_to_name = {}
-        types = json.loads(registry.registry)["types"]
-        type_by_id = {entry["id"]: entry for entry in types}
-
-        # Pass 1: Gather simple types
-        for type_entry in types:
-            type_id = type_entry["id"]
-            type_def = type_entry["type"]["def"]
-            type_path = type_entry["type"].get("path")
-            if type_entry.get("params") or "variant" in type_def:
-                continue
-            if type_path:
-                type_name = type_path[-1]
-                registry_type_map[type_name] = type_id
-                type_id_to_name[type_id] = type_name
-            else:
-                # Possibly a primitive
-                if "primitive" in type_def:
-                    prim_name = type_def["primitive"]
-                    registry_type_map[prim_name] = type_id
-                    type_id_to_name[type_id] = prim_name
-
-        # Pass 2: Resolve remaining types
-        pending_ids = set(type_by_id.keys()) - set(type_id_to_name.keys())
-
-        def resolve_type_definition(type_id_):
-            type_entry_ = type_by_id[type_id_]
-            type_def_ = type_entry_["type"]["def"]
-            type_path_ = type_entry_["type"].get("path", [])
-            type_params = type_entry_["type"].get("params", [])
-
-            if type_id_ in type_id_to_name:
-                return type_id_to_name[type_id_]
-
-            # Resolve complex types with paths (including generics like Option etc)
-            if type_path_:
-                type_name_ = type_path_[-1]
-                if type_params:
-                    inner_names = []
-                    for param in type_params:
-                        dep_id = param["type"]
-                        if dep_id not in type_id_to_name:
-                            return None
-                        inner_names.append(type_id_to_name[dep_id])
-                    return f"{type_name_}<{', '.join(inner_names)}>"
-                if "variant" in type_def_:
-                    return None
-                return type_name_
-
-            elif "sequence" in type_def_:
-                sequence_type_id = type_def_["sequence"]["type"]
-                inner_type = type_id_to_name.get(sequence_type_id)
-                if inner_type:
-                    type_name_ = f"Vec<{inner_type}>"
-                    return type_name_
-
-            elif "array" in type_def_:
-                array_type_id = type_def_["array"]["type"]
-                inner_type = type_id_to_name.get(array_type_id)
-                maybe_len = type_def_["array"].get("len")
-                if inner_type:
-                    if maybe_len:
-                        type_name_ = f"[{inner_type}; {maybe_len}]"
-                    else:
-                        type_name_ = f"[{inner_type}]"
-                    return type_name_
-
-            elif "compact" in type_def_:
-                compact_type_id = type_def_["compact"]["type"]
-                inner_type = type_id_to_name.get(compact_type_id)
-                if inner_type:
-                    type_name_ = f"Compact<{inner_type}>"
-                    return type_name_
-
-            elif "tuple" in type_def_:
-                tuple_type_ids = type_def_["tuple"]
-                type_names = []
-                for inner_type_id in tuple_type_ids:
-                    if inner_type_id not in type_id_to_name:
-                        return None
-                    type_names.append(type_id_to_name[inner_type_id])
-                type_name_ = ", ".join(type_names)
-                type_name_ = f"({type_name_})"
-                return type_name_
-
-            elif "variant" in type_def_:
-                return None
-
-            return None
-
-        resolved_type = True
-        while resolved_type and pending_ids:
-            resolved_type = False
-            for type_id in list(pending_ids):
-                name = resolve_type_definition(type_id)
-                if name is not None:
-                    type_id_to_name[type_id] = name
-                    registry_type_map[name] = type_id
-                    pending_ids.remove(type_id)
-                    resolved_type = True
-
-        self.registry_type_map = registry_type_map
-        self.type_id_to_name = type_id_to_name
-
-    def reload_type_registry(
-        self, use_remote_preset: bool = True, auto_discover: bool = True
-    ):
-        """
-        Reload type registry and preset used to instantiate the `AsyncSubstrateInterface` object. Useful to
-        periodically apply changes in type definitions when a runtime upgrade occurred
-
-        Args:
-            use_remote_preset: When True preset is downloaded from Github master,
-                otherwise use files from local installed scalecodec package
-            auto_discover: Whether to automatically discover the type_registry
-                presets based on the chain name and typer registry
-        """
-        self.runtime_config.clear_type_registry()
-
-        self.runtime_config.implements_scale_info = self.implements_scaleinfo
-
-        # Load metadata types in runtime configuration
-        self.runtime_config.update_type_registry(load_type_registry_preset(name="core"))
-        self.apply_type_registry_presets(
-            use_remote_preset=use_remote_preset, auto_discover=auto_discover
-        )
-
-    def apply_type_registry_presets(
-        self, use_remote_preset: bool = True, auto_discover: bool = True
-    ):
-        if self.type_registry_preset is not None:
-            # Load type registry according to preset
-            type_registry_preset_dict = load_type_registry_preset(
-                name=self.type_registry_preset, use_remote_preset=use_remote_preset
-            )
-
-            if not type_registry_preset_dict:
-                raise ValueError(
-                    f"Type registry preset '{self.type_registry_preset}' not found"
-                )
-
-        elif auto_discover:
-            # Try to auto discover type registry preset by chain name
-            type_registry_name = self.chain.lower().replace(" ", "-")
-            try:
-                type_registry_preset_dict = load_type_registry_preset(
-                    type_registry_name
-                )
-                logger.debug(
-                    f"Auto set type_registry_preset to {type_registry_name} ..."
-                )
-                self.type_registry_preset = type_registry_name
-            except ValueError:
-                type_registry_preset_dict = None
-
-        else:
-            type_registry_preset_dict = None
-
-        if type_registry_preset_dict:
-            # Load type registries in runtime configuration
-            if self.implements_scaleinfo is False:
-                # Only runtime with no embedded types in metadata need the default set of explicit defined types
-                self.runtime_config.update_type_registry(
-                    load_type_registry_preset(
-                        "legacy", use_remote_preset=use_remote_preset
-                    )
-                )
-
-            if self.type_registry_preset != "legacy":
-                self.runtime_config.update_type_registry(type_registry_preset_dict)
-
-        if self.type_registry:
-            # Load type registries in runtime configuration
-            self.runtime_config.update_type_registry(self.type_registry)
-
     def extension_call(self, name, **kwargs):
         raise NotImplementedError(
             "Extensions not implemented in AsyncSubstrateInterface"
@@ -850,13 +780,16 @@ class SubstrateMixin(ABC):
             "payload": {"jsonrpc": "2.0", "method": method, "params": params},
         }
 
-    def _encode_scale(self, type_string, value: Any) -> bytes:
+    def _encode_scale(
+        self, type_string, value: Any, runtime: Optional[Runtime] = None
+    ) -> bytes:
         """
         Helper function to encode arbitrary data into SCALE-bytes for given RUST type_string
 
         Args:
             type_string: the type string of the SCALE object for decoding
             value: value to encode
+            runtime: Optional Runtime whose registry to use for encoding
 
         Returns:
             encoded bytes
@@ -864,14 +797,16 @@ class SubstrateMixin(ABC):
         if value is None:
             result = b"\x00"
         else:
+            if not runtime:
+                runtime = self.runtime
             try:
                 vec_acct_id = (
-                    f"scale_info::{self.registry_type_map['Vec<AccountId32>']}"
+                    f"scale_info::{runtime.registry_type_map['Vec<AccountId32>']}"
                 )
             except KeyError:
                 vec_acct_id = "scale_info::152"
             try:
-                optional_acct_u16 = f"scale_info::{self.registry_type_map['Option<(AccountId32, u16)>']}"
+                optional_acct_u16 = f"scale_info::{runtime.registry_type_map['Option<(AccountId32, u16)>']}"
             except KeyError:
                 optional_acct_u16 = "scale_info::579"
 
@@ -921,7 +856,8 @@ class SubstrateMixin(ABC):
             )
         return result
 
-    def _encode_account_id(self, account) -> bytes:
+    @staticmethod
+    def _encode_account_id(account) -> bytes:
         """Encode an account ID into bytes.
 
         Args:

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -91,6 +91,20 @@ class Runtime:
         self.runtime_version = runtime_info.get("specVersion")
         self.transaction_version = runtime_info.get("transactionVersion")
 
+    @property
+    def implements_scaleinfo(self) -> Optional[bool]:
+        """
+        Returns True if current runtime implements a `PortableRegistry` (`MetadataV14` and higher)
+
+        Returns
+        -------
+        bool
+        """
+        if self.metadata:
+            return self.metadata.portable_registry is not None
+        else:
+            return None
+
     def __str__(self):
         return f"Runtime: {self.chain} | {self.config}"
 

--- a/async_substrate_interface/utils/cache.py
+++ b/async_substrate_interface/utils/cache.py
@@ -228,7 +228,7 @@ class CachedFetcher:
 
         if self._cache_key_index is not None:
             key_name = list(bound.arguments)[self._cache_key_index]
-            return bound.arguments[key_name][self._cache_key_index]
+            return bound.arguments[key_name]
 
         return (tuple(bound.arguments.items()),)
 

--- a/async_substrate_interface/utils/cache.py
+++ b/async_substrate_interface/utils/cache.py
@@ -228,7 +228,7 @@ class CachedFetcher:
 
         if self._cache_key_index is not None:
             key_name = list(bound.arguments)[self._cache_key_index]
-            return bound.arguments[key_name]
+            return bound.arguments[key_name][self._cache_key_index]
 
         return (tuple(bound.arguments.items()),)
 

--- a/tests/helpers/settings.py
+++ b/tests/helpers/settings.py
@@ -32,3 +32,5 @@ BABE_NODE_URL = environ.get("SUBSTRATE_BABE_NODE_URL") or POLKADOT_NODE_URL
 AURA_NODE_URL = (
     environ.get("SUBSTRATE_AURA_NODE_URL") or "wss://acala-rpc-1.aca-api.network"
 )
+
+ARCHIVE_ENTRYPOINT = "wss://archive.chain.opentensor.ai:443"

--- a/tests/integration_tests/test_async_substrate_interface.py
+++ b/tests/integration_tests/test_async_substrate_interface.py
@@ -1,0 +1,32 @@
+import pytest
+
+from async_substrate_interface.async_substrate import AsyncSubstrateInterface
+from async_substrate_interface.types import ScaleObj
+from tests.helpers.settings import ARCHIVE_ENTRYPOINT
+
+
+@pytest.mark.asyncio
+async def test_legacy_decoding():
+    # roughly 4000 blocks before metadata v15 was added
+    pre_metadata_v15_block = 3_010_611
+
+    async with AsyncSubstrateInterface(ARCHIVE_ENTRYPOINT) as substrate:
+        block_hash = await substrate.get_block_hash(pre_metadata_v15_block)
+        events = await substrate.get_events(block_hash)
+        assert isinstance(events, list)
+
+        query_map_result = await substrate.query_map(
+            module="SubtensorModule",
+            storage_function="NetworksAdded",
+            block_hash=block_hash,
+        )
+        async for key, value in query_map_result:
+            assert isinstance(key, int)
+            assert isinstance(value, ScaleObj)
+
+        timestamp = await substrate.query(
+            "Timestamp",
+            "Now",
+            block_hash=block_hash,
+        )
+        assert timestamp.value == 1716358476004

--- a/tests/integration_tests/test_substrate_interface.py
+++ b/tests/integration_tests/test_substrate_interface.py
@@ -1,0 +1,29 @@
+from async_substrate_interface.sync_substrate import SubstrateInterface
+from async_substrate_interface.types import ScaleObj
+from tests.helpers.settings import ARCHIVE_ENTRYPOINT
+
+
+def test_legacy_decoding():
+    # roughly 4000 blocks before metadata v15 was added
+    pre_metadata_v15_block = 3_010_611
+
+    with SubstrateInterface(ARCHIVE_ENTRYPOINT) as substrate:
+        block_hash = substrate.get_block_hash(pre_metadata_v15_block)
+        events = substrate.get_events(block_hash)
+        assert isinstance(events, list)
+
+        query_map_result = substrate.query_map(
+            module="SubtensorModule",
+            storage_function="NetworksAdded",
+            block_hash=block_hash,
+        )
+        for key, value in query_map_result:
+            assert isinstance(key, int)
+            assert isinstance(value, ScaleObj)
+
+        timestamp = substrate.query(
+            "Timestamp",
+            "Now",
+            block_hash=block_hash,
+        )
+        assert timestamp.value == 1716358476004

--- a/tests/unit_tests/asyncio_/test_substrate_interface.py
+++ b/tests/unit_tests/asyncio_/test_substrate_interface.py
@@ -6,9 +6,7 @@ from websockets.exceptions import InvalidURI
 
 from async_substrate_interface.async_substrate import AsyncSubstrateInterface
 from async_substrate_interface.types import ScaleObj
-
-
-ARCHIVE_ENTRYPOINT = "wss://archive.chain.opentensor.ai:443"
+from tests.helpers.settings import ARCHIVE_ENTRYPOINT
 
 
 @pytest.mark.asyncio
@@ -137,9 +135,9 @@ async def test_legacy_decoding():
             assert isinstance(key, int)
             assert isinstance(value, ScaleObj)
 
-        unix = await substrate.query(
+        timestamp = await substrate.query(
             "Timestamp",
             "Now",
             block_hash=block_hash,
         )
-        assert unix.value == 1716358476004
+        assert timestamp.value == 1716358476004

--- a/tests/unit_tests/asyncio_/test_substrate_interface.py
+++ b/tests/unit_tests/asyncio_/test_substrate_interface.py
@@ -6,7 +6,6 @@ from websockets.exceptions import InvalidURI
 
 from async_substrate_interface.async_substrate import AsyncSubstrateInterface
 from async_substrate_interface.types import ScaleObj
-from tests.helpers.settings import ARCHIVE_ENTRYPOINT
 
 
 @pytest.mark.asyncio
@@ -114,30 +113,3 @@ async def test_websocket_shutdown_timer():
         await substrate.get_chain_head()
         await asyncio.sleep(6)  # same sleep time as before
         assert substrate.ws._initialized is True  # connection should still be open
-
-
-@pytest.mark.asyncio
-async def test_legacy_decoding():
-    # roughly 4000 blocks before metadata v15 was added
-    pre_metadata_v15_block = 3_010_611
-
-    async with AsyncSubstrateInterface(ARCHIVE_ENTRYPOINT) as substrate:
-        block_hash = await substrate.get_block_hash(pre_metadata_v15_block)
-        events = await substrate.get_events(block_hash)
-        assert isinstance(events, list)
-
-        query_map_result = await substrate.query_map(
-            module="SubtensorModule",
-            storage_function="NetworksAdded",
-            block_hash=block_hash,
-        )
-        async for key, value in query_map_result:
-            assert isinstance(key, int)
-            assert isinstance(value, ScaleObj)
-
-        timestamp = await substrate.query(
-            "Timestamp",
-            "Now",
-            block_hash=block_hash,
-        )
-        assert timestamp.value == 1716358476004

--- a/tests/unit_tests/asyncio_/test_substrate_interface.py
+++ b/tests/unit_tests/asyncio_/test_substrate_interface.py
@@ -120,7 +120,8 @@ async def test_websocket_shutdown_timer():
 
 @pytest.mark.asyncio
 async def test_legacy_decoding():
-    pre_metadata_v15_block = 3_014_300  # several blocks before metadata v15 was added
+    # roughly 4000 blocks before metadata v15 was added
+    pre_metadata_v15_block = 3_010_611
 
     async with AsyncSubstrateInterface(ARCHIVE_ENTRYPOINT) as substrate:
         block_hash = await substrate.get_block_hash(pre_metadata_v15_block)
@@ -135,3 +136,10 @@ async def test_legacy_decoding():
         async for key, value in query_map_result:
             assert isinstance(key, int)
             assert isinstance(value, ScaleObj)
+
+        unix = await substrate.query(
+            "Timestamp",
+            "Now",
+            block_hash=block_hash,
+        )
+        assert unix.value == 1716358476004

--- a/tests/unit_tests/sync/test_substrate_interface.py
+++ b/tests/unit_tests/sync/test_substrate_interface.py
@@ -3,6 +3,8 @@ from unittest.mock import MagicMock
 from async_substrate_interface.sync_substrate import SubstrateInterface
 from async_substrate_interface.types import ScaleObj
 
+from tests.helpers.settings import ARCHIVE_ENTRYPOINT
+
 
 def test_runtime_call(monkeypatch):
     substrate = SubstrateInterface("ws://localhost", _mock=True)
@@ -72,3 +74,30 @@ def test_runtime_call(monkeypatch):
     substrate.rpc_request.assert_any_call(
         "state_call", ["SubstrateApi_SubstrateMethod", "", None]
     )
+    substrate.close()
+
+
+def test_legacy_decoding():
+    # roughly 4000 blocks before metadata v15 was added
+    pre_metadata_v15_block = 3_010_611
+
+    with SubstrateInterface(ARCHIVE_ENTRYPOINT) as substrate:
+        block_hash = substrate.get_block_hash(pre_metadata_v15_block)
+        events = substrate.get_events(block_hash)
+        assert isinstance(events, list)
+
+        query_map_result = substrate.query_map(
+            module="SubtensorModule",
+            storage_function="NetworksAdded",
+            block_hash=block_hash,
+        )
+        for key, value in query_map_result:
+            assert isinstance(key, int)
+            assert isinstance(value, ScaleObj)
+
+        timestamp = substrate.query(
+            "Timestamp",
+            "Now",
+            block_hash=block_hash,
+        )
+        assert timestamp.value == 1716358476004

--- a/tests/unit_tests/sync/test_substrate_interface.py
+++ b/tests/unit_tests/sync/test_substrate_interface.py
@@ -3,8 +3,6 @@ from unittest.mock import MagicMock
 from async_substrate_interface.sync_substrate import SubstrateInterface
 from async_substrate_interface.types import ScaleObj
 
-from tests.helpers.settings import ARCHIVE_ENTRYPOINT
-
 
 def test_runtime_call(monkeypatch):
     substrate = SubstrateInterface("ws://localhost", _mock=True)
@@ -75,29 +73,3 @@ def test_runtime_call(monkeypatch):
         "state_call", ["SubstrateApi_SubstrateMethod", "", None]
     )
     substrate.close()
-
-
-def test_legacy_decoding():
-    # roughly 4000 blocks before metadata v15 was added
-    pre_metadata_v15_block = 3_010_611
-
-    with SubstrateInterface(ARCHIVE_ENTRYPOINT) as substrate:
-        block_hash = substrate.get_block_hash(pre_metadata_v15_block)
-        events = substrate.get_events(block_hash)
-        assert isinstance(events, list)
-
-        query_map_result = substrate.query_map(
-            module="SubtensorModule",
-            storage_function="NetworksAdded",
-            block_hash=block_hash,
-        )
-        for key, value in query_map_result:
-            assert isinstance(key, int)
-            assert isinstance(value, ScaleObj)
-
-        timestamp = substrate.query(
-            "Timestamp",
-            "Now",
-            block_hash=block_hash,
-        )
-        assert timestamp.value == 1716358476004

--- a/tests/unit_tests/test_cache.py
+++ b/tests/unit_tests/test_cache.py
@@ -71,8 +71,11 @@ async def test_cached_fetcher_propagates_errors():
 @pytest.mark.asyncio
 async def test_cached_fetcher_eviction():
     """Tests that LRU eviction works in CachedFetcher."""
-    mock_method = mock.AsyncMock(side_effect=lambda x: f"val_{x}")
-    fetcher = CachedFetcher(max_size=2, method=mock_method)
+
+    async def side_effect_method(x):
+        return f"val_{x}"
+
+    fetcher = CachedFetcher(max_size=2, method=side_effect_method)
 
     # Fill cache
     await fetcher("key1")


### PR DESCRIPTION
AsyncSubstrateInterface has a problem. As it was ported from the synchronous version of SubstrateInterface, the `self.runtime` would always be valid in a synchronous context, but in an async context, where you may be concurrently querying multiple blocks with differing runtimes, there are potential issues. As the runtime version does not change often, this is unlikely to occur, but it certainly can, and when it does it's incredibly difficult to locate the source of the problems. 

This PR addresses those issues by ensuring that we always create Runtime objects, and pass those around, rather than relying on the `self.runtime` to be correct at any given time.

The end-users will be completely unaffected negatively, as they do not need to specify Runtimes, but may see some speed improvements in various chained calls that call `AsyncSubstrateInterface.init_runtime`, in addition to better assurance of correctness.

~~The only issue I see may come from subscription handlers. Though I will investigate this further before finishing the PR and setting it R4R.~~ Unaffected

Added benefit: this made it easy to add in legacy Metadata V14 support, which will resolve https://github.com/opentensor/async-substrate-interface/issues/112