### PR TITLE
Only use v14 decoding for events

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -823,6 +823,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 if ss58_prefix_constant:
                     self.ss58_format = ss58_prefix_constant.value
                     runtime.ss58_format = ss58_prefix_constant.value
+                    runtime.runtime_config.ss58_format = ss58_prefix_constant.value
         self.initialized = True
         self._initializing = False
 

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -1965,7 +1965,10 @@ class AsyncSubstrateInterface(SubstrateMixin):
             block_hash = await self.get_chain_head()
 
         storage_obj = await self.query(
-            module="System", storage_function="Events", block_hash=block_hash, force_legacy_decode=True
+            module="System",
+            storage_function="Events",
+            block_hash=block_hash,
+            force_legacy_decode=True,
         )
         # bt-decode Metadata V15 is not ideal for events. Force legacy decoding for this
         if storage_obj:
@@ -2178,7 +2181,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         storage_item: Optional[ScaleType] = None,
         result_handler: Optional[ResultHandler] = None,
         runtime: Optional[Runtime] = None,
-        force_legacy_decode: bool = False
+        force_legacy_decode: bool = False,
     ) -> tuple[Any, bool]:
         """
         Processes the RPC call response by decoding it, returning it as is, or setting a handler for subscriptions,
@@ -2213,7 +2216,9 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 q = bytes(query_value)
             else:
                 q = query_value
-            result = await self.decode_scale(value_scale_type, q, runtime=runtime, force_legacy=force_legacy_decode)
+            result = await self.decode_scale(
+                value_scale_type, q, runtime=runtime, force_legacy=force_legacy_decode
+            )
         if asyncio.iscoroutinefunction(result_handler):
             # For multipart responses as a result of subscriptions.
             message, bool_result = await result_handler(result, subscription_id)
@@ -2228,7 +2233,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         result_handler: Optional[ResultHandler] = None,
         attempt: int = 1,
         runtime: Optional[Runtime] = None,
-        force_legacy_decode: bool = False
+        force_legacy_decode: bool = False,
     ) -> RequestManager.RequestResults:
         request_manager = RequestManager(payloads)
 
@@ -2273,7 +2278,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                                 storage_item,
                                 result_handler,
                                 runtime=runtime,
-                                force_legacy_decode=force_legacy_decode
+                                force_legacy_decode=force_legacy_decode,
                             )
 
                             request_manager.add_response(
@@ -2305,7 +2310,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                             storage_item,
                             result_handler,
                             attempt + 1,
-                            force_legacy_decode
+                            force_legacy_decode,
                         )
 
         return request_manager.get_results()
@@ -3331,7 +3336,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         subscription_handler=None,
         reuse_block_hash: bool = False,
         runtime: Optional[Runtime] = None,
-        force_legacy_decode: bool = False
+        force_legacy_decode: bool = False,
     ) -> Optional[Union["ScaleObj", Any]]:
         """
         Queries substrate. This should only be used when making a single request. For multiple requests,
@@ -3364,7 +3369,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
             storage_item,
             result_handler=subscription_handler,
             runtime=runtime,
-            force_legacy_decode=force_legacy_decode
+            force_legacy_decode=force_legacy_decode,
         )
         result = responses[preprocessed.queryable][0]
         if isinstance(result, (list, tuple, int, float)):

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -999,7 +999,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         else:
             if not runtime:
                 runtime = await self.init_runtime(block_hash=block_hash)
-            if runtime.metadata_v15 is not None or force_legacy is True:
+            if runtime.metadata_v15 is not None and force_legacy is False:
                 obj = decode_by_type_string(type_string, runtime.registry, scale_bytes)
                 if self.decode_ss58:
                     try:
@@ -1930,7 +1930,13 @@ class AsyncSubstrateInterface(SubstrateMixin):
                     if key == "who":
                         who = ss58_encode(bytes(value[0]), self.ss58_format)
                         attributes["who"] = who
-                    if isinstance(value, dict):
+                    elif key == "from":
+                        who_from = ss58_encode(bytes(value[0]), self.ss58_format)
+                        attributes["from"] = who_from
+                    elif key == "to":
+                        who_to = ss58_encode(bytes(value[0]), self.ss58_format)
+                        attributes["to"] = who_to
+                    elif isinstance(value, dict):
                         # Convert nested single-key dictionaries to their keys as strings
                         for sub_key, sub_value in value.items():
                             if isinstance(sub_value, dict):
@@ -1958,16 +1964,12 @@ class AsyncSubstrateInterface(SubstrateMixin):
             block_hash = await self.get_chain_head()
 
         storage_obj = await self.query(
-            module="System", storage_function="Events", block_hash=block_hash
+            module="System", storage_function="Events", block_hash=block_hash, force_legacy_decode=True
         )
+        # bt-decode Metadata V15 is not ideal for events. Force legacy decoding for this
         if storage_obj:
             for item in list(storage_obj):
-                try:
-                    events.append(convert_event_data(item))
-                except (
-                    AttributeError
-                ):  # indicates this was legacy decoded with scalecodec
-                    events.append(item)
+                events.append(item)
         return events
 
     async def get_metadata(self, block_hash=None) -> MetadataV15:
@@ -2175,6 +2177,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         storage_item: Optional[ScaleType] = None,
         result_handler: Optional[ResultHandler] = None,
         runtime: Optional[Runtime] = None,
+        force_legacy_decode: bool = False
     ) -> tuple[Any, bool]:
         """
         Processes the RPC call response by decoding it, returning it as is, or setting a handler for subscriptions,
@@ -2187,6 +2190,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
             storage_item: The ScaleType object used for decoding ScaleBytes results
             result_handler: the result handler coroutine used for handling longer-running subscriptions
             runtime: Optional Runtime to use for decoding. If not specified, the currently-loaded `self.runtime` is used
+            force_legacy_decode: Whether to force the use of the legacy Metadata V14 decoder
 
         Returns:
              (decoded response, completion)
@@ -2208,7 +2212,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 q = bytes(query_value)
             else:
                 q = query_value
-            result = await self.decode_scale(value_scale_type, q, runtime=runtime)
+            result = await self.decode_scale(value_scale_type, q, runtime=runtime, force_legacy=force_legacy_decode)
         if asyncio.iscoroutinefunction(result_handler):
             # For multipart responses as a result of subscriptions.
             message, bool_result = await result_handler(result, subscription_id)
@@ -2223,6 +2227,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         result_handler: Optional[ResultHandler] = None,
         attempt: int = 1,
         runtime: Optional[Runtime] = None,
+        force_legacy_decode: bool = False
     ) -> RequestManager.RequestResults:
         request_manager = RequestManager(payloads)
 
@@ -2267,6 +2272,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                                 storage_item,
                                 result_handler,
                                 runtime=runtime,
+                                force_legacy_decode=force_legacy_decode
                             )
 
                             request_manager.add_response(
@@ -2298,6 +2304,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                             storage_item,
                             result_handler,
                             attempt + 1,
+                            force_legacy_decode
                         )
 
         return request_manager.get_results()
@@ -3323,6 +3330,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         subscription_handler=None,
         reuse_block_hash: bool = False,
         runtime: Optional[Runtime] = None,
+        force_legacy_decode: bool = False
     ) -> Optional[Union["ScaleObj", Any]]:
         """
         Queries substrate. This should only be used when making a single request. For multiple requests,
@@ -3355,6 +3363,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
             storage_item,
             result_handler=subscription_handler,
             runtime=runtime,
+            force_legacy_decode=force_legacy_decode
         )
         result = responses[preprocessed.queryable][0]
         if isinstance(result, (list, tuple, int, float)):

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -1634,7 +1634,10 @@ class SubstrateInterface(SubstrateMixin):
             block_hash = self.get_chain_head()
 
         storage_obj = self.query(
-            module="System", storage_function="Events", block_hash=block_hash, force_legacy_decode=True
+            module="System",
+            storage_function="Events",
+            block_hash=block_hash,
+            force_legacy_decode=True,
         )
         # bt-decode Metadata V15 is not ideal for events. Force legacy decoding for this
         if storage_obj:
@@ -1821,7 +1824,7 @@ class SubstrateInterface(SubstrateMixin):
         value_scale_type: Optional[str] = None,
         storage_item: Optional[ScaleType] = None,
         result_handler: Optional[ResultHandler] = None,
-        force_legacy_decode: bool = False
+        force_legacy_decode: bool = False,
     ) -> tuple[Any, bool]:
         """
         Processes the RPC call response by decoding it, returning it as is, or setting a handler for subscriptions,
@@ -1855,7 +1858,9 @@ class SubstrateInterface(SubstrateMixin):
                 q = bytes(query_value)
             else:
                 q = query_value
-            result = self.decode_scale(value_scale_type, q, force_legacy=force_legacy_decode)
+            result = self.decode_scale(
+                value_scale_type, q, force_legacy=force_legacy_decode
+            )
         if isinstance(result_handler, Callable):
             # For multipart responses as a result of subscriptions.
             message, bool_result = result_handler(result, subscription_id)
@@ -1869,7 +1874,7 @@ class SubstrateInterface(SubstrateMixin):
         storage_item: Optional[ScaleType] = None,
         result_handler: Optional[ResultHandler] = None,
         attempt: int = 1,
-        force_legacy_decode: bool = False
+        force_legacy_decode: bool = False,
     ) -> RequestManager.RequestResults:
         request_manager = RequestManager(payloads)
         _received = {}
@@ -1903,7 +1908,7 @@ class SubstrateInterface(SubstrateMixin):
                         storage_item,
                         result_handler,
                         attempt + 1,
-                        force_legacy_decode
+                        force_legacy_decode,
                     )
             if "id" in response:
                 _received[response["id"]] = response
@@ -1935,7 +1940,7 @@ class SubstrateInterface(SubstrateMixin):
                             value_scale_type,
                             storage_item,
                             result_handler,
-                            force_legacy_decode
+                            force_legacy_decode,
                         )
                         request_manager.add_response(
                             item_id, decoded_response, complete
@@ -2874,7 +2879,7 @@ class SubstrateInterface(SubstrateMixin):
         raw_storage_key: Optional[bytes] = None,
         subscription_handler=None,
         reuse_block_hash: bool = False,
-        force_legacy_decode: bool = False
+        force_legacy_decode: bool = False,
     ) -> Optional[Union["ScaleObj", Any]]:
         """
         Queries substrate. This should only be used when making a single request. For multiple requests,
@@ -2900,7 +2905,7 @@ class SubstrateInterface(SubstrateMixin):
             value_scale_type,
             storage_item,
             result_handler=subscription_handler,
-            force_legacy_decode=force_legacy_decode
+            force_legacy_decode=force_legacy_decode,
         )
         result = responses[preprocessed.queryable][0]
         if isinstance(result, (list, tuple, int, float)):

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -568,6 +568,7 @@ class SubstrateInterface(SubstrateMixin):
                 if ss58_prefix_constant:
                     self.ss58_format = ss58_prefix_constant.value
                     self.runtime.ss58_format = ss58_prefix_constant.value
+                    self.runtime.runtime_config.ss58_format = ss58_prefix_constant.value
         self.initialized = True
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/tests/integration_tests/test_async_substrate_interface.py
+++ b/tests/integration_tests/test_async_substrate_interface.py
@@ -115,3 +115,20 @@ async def test_fully_exhaust_query_map():
             fully_exhausted_records_count += 1
         assert fully_exhausted_records_count == initial_records_count_fully_exhaust
         assert initial_records_count_fully_exhaust == exhausted_records_count
+
+
+@pytest.mark.asyncio
+async def test_get_events_proper_decoding():
+    # known block/hash pair that has the events we seek to decode
+    block = 5846788
+    block_hash = "0x0a1c45063a59b934bfee827caa25385e60d5ec1fd8566a58b5cc4affc4eec412"
+
+    async with AsyncSubstrateInterface(ARCHIVE_ENTRYPOINT) as substrate:
+        all_events = await substrate.get_events(block_hash=block_hash)
+        event = all_events[1]
+        print(type(event["attributes"]))
+        assert event["attributes"] == (
+            "5G1NjW9YhXLadMWajvTkfcJy6up3yH2q1YzMXDTi6ijanChe",
+            30,
+            "0xa6b4e5c8241d60ece0c25056b19f7d21ae845269fc771ad46bf3e011865129a5",
+        )

--- a/tests/integration_tests/test_substrate_interface.py
+++ b/tests/integration_tests/test_substrate_interface.py
@@ -68,3 +68,19 @@ def test_ss58_conversion():
             if len(value.value) > 0:
                 for decoded_key in value.value:
                     assert isinstance(decoded_key, str)
+
+
+def test_get_events_proper_decoding():
+    # known block/hash pair that has the events we seek to decode
+    block = 5846788
+    block_hash = "0x0a1c45063a59b934bfee827caa25385e60d5ec1fd8566a58b5cc4affc4eec412"
+
+    with SubstrateInterface(ARCHIVE_ENTRYPOINT) as substrate:
+        all_events = substrate.get_events(block_hash=block_hash)
+        event = all_events[1]
+        print(type(event["attributes"]))
+        assert event["attributes"] == (
+            "5G1NjW9YhXLadMWajvTkfcJy6up3yH2q1YzMXDTi6ijanChe",
+            30,
+            "0xa6b4e5c8241d60ece0c25056b19f7d21ae845269fc771ad46bf3e011865129a5",
+        )


### PR DESCRIPTION
For events, the Python is the same speed at decoding as bt-decode (sometimes faster). However, the Python scalecodec offers significantly better decoding, and doesn't rely on us hacking it after the fact.

Compare the following.
bt-decode
```python
{'phase': 'ApplyExtrinsic', 'extrinsic_idx': 1, 'event': {'module_id': 'SubtensorModule', 'event_id': 'CRV3WeightsCommitted', 'attributes': (((174, 102, 210, 111, 237, 83, 159, 197, 1, 180, 52, 15, 170, 239, 101, 226, 15, 235, 13, 191, 56, 134, 88, 153, 124, 3, 75, 171, 173, 6, 191, 67),), 30, ((166, 180, 229, 200, 36, 29, 96, 236, 224, 194, 80, 86, 177, 159, 125, 33, 174, 132, 82, 105, 252, 119, 26, 212, 107, 243, 224, 17, 134, 81, 41, 165),))}, 'topics': []}
```

scalecodec:
```python
{'phase': 'ApplyExtrinsic', 'extrinsic_idx': 1, 'event': {'event_index': '0759', 'module_id': 'SubtensorModule', 'event_id': 'CRV3WeightsCommitted', 'attributes': ('5G1NjW9YhXLadMWajvTkfcJy6up3yH2q1YzMXDTi6ijanChe', 30, '0xa6b4e5c8241d60ece0c25056b19f7d21ae845269fc771ad46bf3e011865129a5')}, 'event_index': 7, 'module_id': 'SubtensorModule', 'event_id': 'CRV3WeightsCommitted', 'attributes': ('5G1NjW9YhXLadMWajvTkfcJy6up3yH2q1YzMXDTi6ijanChe', 30, '0xa6b4e5c8241d60ece0c25056b19f7d21ae845269fc771ad46bf3e011865129a5'), 'topics': []}
```

The bt-decode version does not decode the SS58s. In addition, we'd previously had to use various hacks to get inner values to parse correctly:

https://github.com/opentensor/async-substrate-interface/blob/35728aba0f8a1c303fadc73239b33c30016c77d3/async_substrate_interface/async_substrate.py#L1933-L1939

which changes `{"pays_fee": {"Yes": ()}}` to `{"pays_fee": "Yes"}`


This rectifies these issues by just using the MetadataV14 decoder.