### PR TITLE
Use scalecodec rather than bt-decode for query_multi

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -2579,7 +2579,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 result.append(
                     (
                         storage_key,
-                        storage_key.decode_scale_value(change_data),
+                        storage_key.decode_scale_value(change_data).value,
                     ),
                 )
 

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -2168,7 +2168,7 @@ class SubstrateInterface(SubstrateMixin):
                 result.append(
                     (
                         storage_key,
-                        storage_key.decode_scale_value(change_data),
+                        storage_key.decode_scale_value(change_data).value,
                     ),
                 )
 


### PR DESCRIPTION
Catches edgecases where the storage-key has greater context than bt-decode can handle, such as when the result for a query where `scale_info::180 = "FixedU128"` results in a result of `b"\x00"`.

The storagekey is aware of the context that the result should actually be `b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'`

and so correctly decodes it as `{"bits": 0}` rather than raising a ValueError.