### PR TITLE
Release/1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.2 /2025-07-23
+* Use scalecodec rather than bt-decode for query_multi by @thewhaleking in https://github.com/opentensor/async-substrate-interface/pull/152
+
+**Full Changelog**: https://github.com/opentensor/async-substrate-interface/compare/v1.4.1...v1.4.2
+
 ## 1.4.1 /2025-07-09
 * Missed passing runtime in encoding by @thewhaleking in https://github.com/opentensor/async-substrate-interface/pull/149
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "async-substrate-interface"
-version = "1.4.1"
+version = "1.4.2"
 description = "Asyncio library for interacting with substrate. Mostly API-compatible with py-substrate-interface"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## 1.4.2 /2025-07-23
* Use scalecodec rather than bt-decode for query_multi by @thewhaleking in https://github.com/opentensor/async-substrate-interface/pull/152

**Full Changelog**: https://github.com/opentensor/async-substrate-interface/compare/v1.4.1...v1.4.2