### PR TITLE
Add "Token" to caught error messages for extrinsic receipts

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -326,6 +326,12 @@ class AsyncExtrinsicReceipt:
                             "name": "Other",
                             "docs": "Unspecified error occurred",
                         }
+                    elif "Token" in dispatch_error:
+                        self.__error_message = {
+                            "type": "System",
+                            "name": "Token",
+                            "docs": dispatch_error["Token"]
+                        }
 
                 elif not has_transaction_fee_paid_event:
                     if (

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -293,6 +293,12 @@ class ExtrinsicReceipt:
                             "name": "Other",
                             "docs": "Unspecified error occurred",
                         }
+                    elif "Token" in dispatch_error:
+                        self.__error_message = {
+                            "type": "System",
+                            "name": "Token",
+                            "docs": dispatch_error["Token"]
+                        }
 
                 elif not has_transaction_fee_paid_event:
                     if (


### PR DESCRIPTION
Adds extrinsic error message for `{"Token": ...}` like that occurs with "Balances.transfer_keep_alive" when transferring everything (e.g. `{"Token": "NotExpendable"}`)