### PR TITLE
runtime version switching

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -1068,6 +1068,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 return runtime
 
         runtime_version = await self.get_block_runtime_version_for(block_hash)
+
         if runtime_version is None:
             raise SubstrateRequestException(
                 f"No runtime information for block '{block_hash}'"

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -330,7 +330,7 @@ class AsyncExtrinsicReceipt:
                         self.__error_message = {
                             "type": "System",
                             "name": "Token",
-                            "docs": dispatch_error["Token"]
+                            "docs": dispatch_error["Token"],
                         }
 
                 elif not has_transaction_fee_paid_event:

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -297,7 +297,7 @@ class ExtrinsicReceipt:
                         self.__error_message = {
                             "type": "System",
                             "name": "Token",
-                            "docs": dispatch_error["Token"]
+                            "docs": dispatch_error["Token"],
                         }
 
                 elif not has_transaction_fee_paid_event:

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -773,9 +773,6 @@ class SubstrateInterface(SubstrateMixin):
         if block_id is not None:
             if runtime := self.runtime_cache.retrieve(block=block_id):
                 self.runtime = runtime
-                self.runtime.load_runtime()
-                if self.runtime.registry:
-                    self.runtime.load_registry_type_map()
                 return self.runtime
             block_hash = self.get_block_hash(block_id)
 
@@ -785,9 +782,6 @@ class SubstrateInterface(SubstrateMixin):
             self.last_block_hash = block_hash
             if runtime := self.runtime_cache.retrieve(block_hash=block_hash):
                 self.runtime = runtime
-                self.runtime.load_runtime()
-                if self.runtime.registry:
-                    self.runtime.load_registry_type_map()
                 return self.runtime
 
         runtime_version = self.get_block_runtime_version_for(block_hash)
@@ -801,15 +795,9 @@ class SubstrateInterface(SubstrateMixin):
 
         if runtime := self.runtime_cache.retrieve(runtime_version=runtime_version):
             self.runtime = runtime
-            self.runtime.load_runtime()
-            if self.runtime.registry:
-                self.runtime.load_registry_type_map()
-            return runtime
+            return self.runtime
         else:
             self.runtime = self.get_runtime_for_version(runtime_version, block_hash)
-            self.runtime.load_runtime()
-            if self.runtime.registry:
-                self.runtime.load_registry_type_map()
             return self.runtime
 
     def get_runtime_for_version(

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -75,16 +75,25 @@ class RuntimeCache:
             runtime = self.blocks.get(block)
             if runtime is not None:
                 self.last_used = runtime
+                runtime.load_runtime()
+                if runtime.registry:
+                    runtime.load_registry_type_map()
                 return runtime
         if block_hash is not None:
             runtime = self.block_hashes.get(block_hash)
             if runtime is not None:
                 self.last_used = runtime
+                runtime.load_runtime()
+                if runtime.registry:
+                    runtime.load_registry_type_map()
                 return runtime
         if runtime_version is not None:
             runtime = self.versions.get(runtime_version)
             if runtime is not None:
                 self.last_used = runtime
+                runtime.load_runtime()
+                if runtime.registry:
+                    runtime.load_registry_type_map()
                 return runtime
         return None
 


### PR DESCRIPTION
Reloads the runtime type registry when items are pulled from the cache. This is not an ideal long-term solution, but it is a stopgap one. There is something happening where the runtime_config is getting updated somewhere, which is why this is required.