### PR TITLE
DiskCachedAsyncSubstrateInterface: use aiosqlite

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -63,6 +63,7 @@ from async_substrate_interface.utils import (
 from async_substrate_interface.utils.cache import (
     async_sql_lru_cache,
     cached_fetcher,
+    AsyncSqliteDB,
 )
 from async_substrate_interface.utils.decoding import (
     _determine_if_old_runtime_call,
@@ -4025,6 +4026,18 @@ class DiskCachedAsyncSubstrateInterface(AsyncSubstrateInterface):
     """
     Experimental new class that uses disk-caching in addition to memory-caching for the cached methods
     """
+
+    async def close(self):
+        """
+        Closes the substrate connection, and the websocket connection.
+        """
+        try:
+            await self.ws.shutdown()
+        except AttributeError:
+            pass
+        db_conn = AsyncSqliteDB(self.url)
+        if db_conn._db is not None:
+            await db_conn._db.close()
 
     @async_sql_lru_cache(maxsize=SUBSTRATE_CACHE_METHOD_SIZE)
     async def get_parent_block_hash(self, block_hash):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
   "bt-decode==v0.6.0",
   "scalecodec~=1.2.11",
   "websockets>=14.1",
-  "xxhash"
+  "xxhash",
+  "aiosqlite>=0.21.0,<1.0.0"
 ]
 
 requires-python = ">=3.9,<3.14"


### PR DESCRIPTION
There is a potential race condition in the current implementation of the disk caching mechanisms used in `DiskCachedAsyncSubstrateInterface`. This resolves that by using `aiosqlite` along with a semi-Singleton SQLite db connection object.