### PR TITLE
Set env vars as str in unit test

### DIFF
--- a/tests/unit_tests/asyncio_/test_env_vars.py
+++ b/tests/unit_tests/asyncio_/test_env_vars.py
@@ -2,8 +2,8 @@ from tests.helpers.fixtures import import_fresh
 
 
 def test_env_vars(monkeypatch):
-    monkeypatch.setenv("SUBSTRATE_CACHE_METHOD_SIZE", 10)
-    monkeypatch.setenv("SUBSTRATE_RUNTIME_CACHE_SIZE", 9)
+    monkeypatch.setenv("SUBSTRATE_CACHE_METHOD_SIZE", "10")
+    monkeypatch.setenv("SUBSTRATE_RUNTIME_CACHE_SIZE", "9")
     async_substrate = import_fresh("async_substrate_interface.async_substrate")
     asi = async_substrate.AsyncSubstrateInterface("", _mock=True)
     assert asi.get_runtime_for_version._max_size == 9

--- a/tests/unit_tests/sync/test_env_vars.py
+++ b/tests/unit_tests/sync/test_env_vars.py
@@ -2,8 +2,8 @@ from tests.helpers.fixtures import import_fresh
 
 
 def test_env_vars(monkeypatch):
-    monkeypatch.setenv("SUBSTRATE_CACHE_METHOD_SIZE", 10)
-    monkeypatch.setenv("SUBSTRATE_RUNTIME_CACHE_SIZE", 9)
+    monkeypatch.setenv("SUBSTRATE_CACHE_METHOD_SIZE", "10")
+    monkeypatch.setenv("SUBSTRATE_RUNTIME_CACHE_SIZE", "9")
     sync_substrate = import_fresh("async_substrate_interface.sync_substrate")
     asi = sync_substrate.SubstrateInterface("", _mock=True)
     assert asi.get_runtime_for_version.cache_parameters()["maxsize"] == 9


### PR DESCRIPTION
While pytest implicitly converts monkeypatched env vars to strings, I don't like warnings. This fixes that.