### PR TITLE
edge case query map keys

### DIFF
--- a/async_substrate_interface/utils/decoding.py
+++ b/async_substrate_interface/utils/decoding.py
@@ -135,11 +135,14 @@ def decode_query_map(
                 if decode_ss58:
                     if kts[kts.index(", ") + 2 : kts.index(")")] == "scale_info::0":
                         item_key = ss58_encode(bytes(item_key[0]), runtime.ss58_format)
-
             else:
-                item_key = tuple(
-                    dk[key + 1] for key in range(len(params), len(param_types) + 1, 2)
-                )
+                try:
+                    item_key = tuple(
+                        dk[key + 1]
+                        for key in range(len(params), len(param_types) + 1, 2)
+                    )
+                except IndexError:
+                    item_key = dk
 
         except Exception as _:
             if not ignore_decoding_errors:

--- a/tests/integration_tests/test_async_substrate_interface.py
+++ b/tests/integration_tests/test_async_substrate_interface.py
@@ -161,3 +161,16 @@ async def test_reconnection():
         bh = await substrate.get_chain_finalised_head()
         assert isinstance(bh, str)
         assert isinstance(await substrate.get_block_number(bh), int)
+
+
+@pytest.mark.asyncio
+async def test_query_map_with_odd_number_of_params():
+    async with AsyncSubstrateInterface(ARCHIVE_ENTRYPOINT, ss58_format=42) as substrate:
+        qm = await substrate.query_map(
+            "SubtensorModule",
+            "Alpha",
+            ["5CoZxgtfhcJKX2HmkwnsN18KbaT9aih9eF3b6qVPTgAUbifj"],
+        )
+        first_record = qm.records[0]
+        assert len(first_record) == 2
+        assert len(first_record[0]) == 4

--- a/tests/integration_tests/test_substrate_interface.py
+++ b/tests/integration_tests/test_substrate_interface.py
@@ -100,3 +100,15 @@ def test_query_multiple():
             storage_function="OwnedHotkeys",
             block_hash=block_hash,
         )
+
+
+def test_query_map_with_odd_number_of_params():
+    with SubstrateInterface(LATENT_LITE_ENTRYPOINT, ss58_format=42) as substrate:
+        qm = substrate.query_map(
+            "SubtensorModule",
+            "Alpha",
+            ["5CoZxgtfhcJKX2HmkwnsN18KbaT9aih9eF3b6qVPTgAUbifj"],
+        )
+        first_record = qm.records[0]
+        assert len(first_record) == 2
+        assert len(first_record[0]) == 4


### PR DESCRIPTION
Edge case where passing weird number of params vs normal param types could result in valid data received and decoded, but unable to create the map.