### PR TITLE
Improve timeout task cancellation

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -2382,8 +2382,12 @@ class AsyncSubstrateInterface(SubstrateMixin):
             for payload in payloads:
                 item_id = await ws.send(payload["payload"])
                 request_manager.add_request(item_id, payload["id"])
+                if len(stringified_payload := str(payload)) < 2_000:
+                    output_payload = stringified_payload
+                else:
+                    output_payload = f"{stringified_payload[:2_000]} (truncated)"
                 logger.debug(
-                    f"Submitted payload ID {payload['id']} with websocket ID {item_id}: {payload}"
+                    f"Submitted payload ID {payload['id']} with websocket ID {item_id}: {output_payload}"
                 )
 
             while True:

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -1904,8 +1904,12 @@ class SubstrateInterface(SubstrateMixin):
                 raw_websocket_logger.debug(f"WEBSOCKET_SEND> {to_send}")
             ws.send(to_send)
             request_manager.add_request(item_id, payload["id"])
+            if len(stringified_payload := str(payload)) < 2_000:
+                output_payload = stringified_payload
+            else:
+                output_payload = f"{stringified_payload[:2_000]} (truncated)"
             logger.debug(
-                f"Submitted payload ID {payload['id']} with websocket ID {item_id}: {payload}"
+                f"Submitted payload ID {payload['id']} with websocket ID {item_id}: {output_payload}"
             )
 
         while True:


### PR DESCRIPTION
The missed `return` when reconnecting caused the cancelled exception to be propagated even when reconnecting. 

Also, we had to check `task.cancelled()` before `task.result()` before checking to see if the result was an exception, because calling `task.result()` or `task.exception()` on a task with a pending `asyncio.CancelledError` raises that exception rather than handling it.

Also improves debug logging.