### PR TITLE
Clean Up Error Handling

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -2545,7 +2545,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         return (await self.rpc_request("chain_getBlockHash", [block_id]))["result"]
 
     async def get_chain_head(self) -> str:
-        result = await self._make_rpc_request(
+        response = await self._make_rpc_request(
             [
                 self.make_payload(
                     "rpc_request",
@@ -2554,10 +2554,11 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 )
             ]
         )
-        if "error" in result[0]:
-            raise SubstrateRequestException(result[0]["error"]["message"])
-        self.last_block_hash = result["rpc_request"][0]["result"]
-        return result["rpc_request"][0]["result"]
+        result = response["rpc_request"][0]
+        if "error" in result:
+            raise SubstrateRequestException(result["error"]["message"])
+        self.last_block_hash = result["result"]
+        return result["result"]
 
     async def compose_call(
         self,

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -2068,7 +2068,7 @@ class SubstrateInterface(SubstrateMixin):
         return self.rpc_request("chain_getBlockHash", [block_id])["result"]
 
     def get_chain_head(self) -> str:
-        result = self._make_rpc_request(
+        response = self._make_rpc_request(
             [
                 self.make_payload(
                     "rpc_request",
@@ -2077,10 +2077,11 @@ class SubstrateInterface(SubstrateMixin):
                 )
             ]
         )
-        if "error" in result[0]:
-            raise SubstrateRequestException(result[0]["error"]["message"])
-        self.last_block_hash = result["rpc_request"][0]["result"]
-        return result["rpc_request"][0]["result"]
+        result = response["rpc_request"][0]
+        if "error" in result:
+            raise SubstrateRequestException(result["error"]["message"])
+        self.last_block_hash = result["result"]
+        return result["result"]
 
     def compose_call(
         self,


### PR DESCRIPTION
Eliminates a lot of double-checking for "error" in response, and adds error checking for this for `get_chain_head`

Resolves #182 

Relies on the fact that all calls to `SubstrateInterface`/`AsyncSubstrateInterface`'s `rpc_request` method checks two things:
1. that the result dict **does not** contain "error"
2. that the result dict **does** contain "result"