### PR TITLE
Avoids ID of 'None' in queries

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -2296,8 +2296,13 @@ class AsyncSubstrateInterface(SubstrateMixin):
                 metadata=runtime.metadata,
             )
         method = "state_getStorageAt"
+        queryable = (
+            str(query_for)
+            if query_for is not None
+            else f"{method}{random.randint(0, 7000)}"
+        )
         return Preprocessed(
-            str(query_for),
+            queryable,
             method,
             [storage_key.to_hex(), block_hash],
             value_scale_type,

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -1820,8 +1820,13 @@ class SubstrateInterface(SubstrateMixin):
                 metadata=self.runtime.metadata,
             )
         method = "state_getStorageAt"
+        queryable = (
+            str(query_for)
+            if query_for is not None
+            else f"{method}{random.randint(0, 7000)}"
+        )
         return Preprocessed(
-            str(query_for),
+            queryable,
             method,
             [storage_key.to_hex(), block_hash],
             value_scale_type,


### PR DESCRIPTION
There were edge cases for queries without original params (i.e. just for storage key and block_hash) where the query was `None` and thus the ID changed to 'None'