### PR TITLE
Fix parameter name conflict in retry substrate _retry() methods

### DIFF
--- a/async_substrate_interface/substrate_addons.py
+++ b/async_substrate_interface/substrate_addons.py
@@ -171,8 +171,8 @@ class RetrySyncSubstrate(SubstrateInterface):
         for method in retry_methods:
             setattr(self, method, partial(self._retry, method))
 
-    def _retry(self, method, *args, **kwargs):
-        method_ = self._original_methods[method]
+    def _retry(self, method_name, *args, **kwargs):
+        method_ = self._original_methods[method_name]
         try:
             return method_(*args, **kwargs)
         except (
@@ -341,8 +341,8 @@ class RetryAsyncSubstrate(AsyncSubstrateInterface):
         self._initializing = False
         await self.initialize()
 
-    async def _retry(self, method, *args, **kwargs):
-        method_ = self._original_methods[method]
+    async def _retry(self, method_name, *args, **kwargs):
+        method_ = self._original_methods[method_name]
         try:
             return await method_(*args, **kwargs)
         except (

--- a/tests/e2e_tests/test_substrate_addons.py
+++ b/tests/e2e_tests/test_substrate_addons.py
@@ -105,3 +105,36 @@ def test_retry_sync_subtensor_archive_node():
         LATENT_LITE_ENTRYPOINT, archive_nodes=[ARCHIVE_ENTRYPOINT]
     ) as substrate:
         assert isinstance((substrate.get_block(block_number=old_block)), dict)
+
+
+@pytest.mark.asyncio
+async def test_retry_async_substrate_runtime_call_with_keyword_args():
+    """Test that runtime_call works with keyword arguments (parameter name conflict fix)."""
+    async with RetryAsyncSubstrate(
+        LATENT_LITE_ENTRYPOINT, retry_forever=True
+    ) as substrate:
+        # This should not raise TypeError due to parameter name conflict
+        # The 'method' kwarg should not conflict with _retry's parameter
+        result = await substrate.runtime_call(
+            api="SwapRuntimeApi",
+            method="current_alpha_price",
+            params=[1],
+            block_hash=None,
+        )
+        assert result is not None
+
+
+def test_retry_sync_substrate_runtime_call_with_keyword_args():
+    """Test that runtime_call works with keyword arguments (parameter name conflict fix)."""
+    with RetrySyncSubstrate(
+        LATENT_LITE_ENTRYPOINT, retry_forever=True
+    ) as substrate:
+        # This should not raise TypeError due to parameter name conflict
+        # The 'method' kwarg should not conflict with _retry's parameter
+        result = substrate.runtime_call(
+            api="SwapRuntimeApi",
+            method="current_alpha_price",
+            params=[1],
+            block_hash=None,
+        )
+        assert result is not None


### PR DESCRIPTION
Fixes a parameter name conflict in `RetryAsyncSubstrate._retry()` and `RetrySyncSubstrate._retry()` that
  caused `TypeError: got multiple values for argument 'method'` when calling methods like
`runtime_call()` with keyword arguments.

The `_retry()` wrapper method used a parameter named `method`, which conflicted with wrapped methods
that also have a `method` parameter. Renamed the parameter to `method_name` to avoid the collision.

Added regression tests to ensure `runtime_call()` works correctly with keyword arguments in both retry
substrate classes.
