### PR TITLE
move metadata methods to SubstrateMixin

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -23,6 +23,7 @@ from typing import (
     cast,
 )
 
+import scalecodec
 import websockets.exceptions
 from bt_decode import MetadataV15, PortableRegistry, decode as decode_by_type_string
 from scalecodec import GenericVariant
@@ -1588,7 +1589,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
     async def get_metadata_storage_functions(
         self, block_hash: Optional[str] = None, runtime: Optional[Runtime] = None
-    ) -> list:
+    ) -> list[dict[str, Any]]:
         """
         Retrieves a list of all storage functions in metadata active at given block_hash (or chaintip if
         block_hash and runtime are omitted)
@@ -1656,7 +1657,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         error_name: str,
         block_hash: Optional[str] = None,
         runtime: Optional[Runtime] = None,
-    ):
+    ) -> Optional[scalecodec.GenericVariant]:
         """
         Retrieves the details of an error for given module name, call function name and block_hash
 
@@ -1678,7 +1679,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
     async def get_metadata_runtime_call_functions(
         self, block_hash: Optional[str] = None, runtime: Optional[Runtime] = None
-    ) -> list[ScaleType]:
+    ) -> list[scalecodec.GenericRuntimeCallDefinition]:
         """
         Get a list of available runtime API calls
 
@@ -1695,7 +1696,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         method: str,
         block_hash: Optional[str] = None,
         runtime: Optional[Runtime] = None,
-    ) -> ScaleType:
+    ) -> scalecodec.GenericRuntimeCallDefinition:
         """
         Get details of a runtime API call. If not supplying `block_hash` or `runtime`, the runtime of the current block
         will be used.
@@ -3369,7 +3370,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         constant_name: str,
         block_hash: Optional[str] = None,
         runtime: Optional[Runtime] = None,
-    ):
+    ) -> Optional[scalecodec.ScaleInfoModuleConstantMetadata]:
         """
         Retrieves the details of a constant for given module name, call function name and block_hash
         (or chaintip if block_hash is omitted)
@@ -4080,7 +4081,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         """
 
         runtime = await self.init_runtime(block_hash=block_hash)
-        return self._get_metadata_event(runtime)
+        return self._get_metadata_event(module_name, event_name, runtime)
 
     async def get_block_number(self, block_hash: Optional[str] = None) -> int:
         """Async version of `substrateinterface.base.get_block_number` method."""

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -6,6 +6,7 @@ from hashlib import blake2b
 from typing import Optional, Union, Callable, Any
 from unittest.mock import MagicMock
 
+import scalecodec
 from bt_decode import MetadataV15, PortableRegistry, decode as decode_by_type_string
 from scalecodec import (
     GenericCall,
@@ -1031,7 +1032,7 @@ class SubstrateInterface(SubstrateMixin):
 
         return extrinsics
 
-    def get_metadata_storage_functions(self, block_hash=None) -> list:
+    def get_metadata_storage_functions(self, block_hash=None) -> list[dict[str, Any]]:
         """
         Retrieves a list of all storage functions in metadata active at given block_hash (or chaintip if block_hash is
         omitted)
@@ -1078,7 +1079,9 @@ class SubstrateInterface(SubstrateMixin):
 
         return self._get_metadata_errors(runtime=runtime)
 
-    def get_metadata_error(self, module_name: str, error_name: str, block_hash=None):
+    def get_metadata_error(
+        self, module_name: str, error_name: str, block_hash=None
+    ) -> Optional[scalecodec.GenericVariant]:
         """
         Retrieves the details of an error for given module name, call function name and block_hash
 
@@ -1098,7 +1101,7 @@ class SubstrateInterface(SubstrateMixin):
 
     def get_metadata_runtime_call_functions(
         self, block_hash: Optional[str] = None
-    ) -> list[ScaleType]:
+    ) -> list[scalecodec.GenericRuntimeCallDefinition]:
         """
         Get a list of available runtime API calls
 
@@ -1110,7 +1113,7 @@ class SubstrateInterface(SubstrateMixin):
 
     def get_metadata_runtime_call_function(
         self, api: str, method: str, block_hash: Optional[str] = None
-    ) -> ScaleType:
+    ) -> scalecodec.GenericRuntimeCallDefinition:
         """
         Get details of a runtime API call
 
@@ -2662,7 +2665,9 @@ class SubstrateInterface(SubstrateMixin):
 
         return self._get_metadata_constants(runtime)
 
-    def get_metadata_constant(self, module_name, constant_name, block_hash=None):
+    def get_metadata_constant(
+        self, module_name, constant_name, block_hash=None
+    ) -> Optional[scalecodec.ScaleInfoModuleConstantMetadata]:
         """
         Retrieves the details of a constant for given module name, call function name and block_hash
         (or chaintip if block_hash is omitted)
@@ -3279,7 +3284,7 @@ class SubstrateInterface(SubstrateMixin):
         return self._get_metadata_events(runtime)
 
     def get_metadata_event(
-        self, module_name, event_name, block_hash=None
+        self, module_name: str, event_name: str, block_hash=None
     ) -> Optional[Any]:
         """
         Retrieves the details of an event for given module name, call function name and block_hash
@@ -3296,7 +3301,7 @@ class SubstrateInterface(SubstrateMixin):
         """
 
         runtime = self.init_runtime(block_hash=block_hash)
-        return self._get_metadata_event(runtime)
+        return self._get_metadata_event(module_name, event_name, runtime)
 
     def get_block_number(self, block_hash: Optional[str] = None) -> int:
         """Async version of `substrateinterface.base.get_block_number` method."""

--- a/async_substrate_interface/types.py
+++ b/async_substrate_interface/types.py
@@ -676,8 +676,8 @@ class SubstrateMixin(ABC):
 
     def serialize_storage_item(
         self,
-        storage_item: ScaleType,
-        module: str,
+        storage_item: scalecodec.ScaleInfoStorageEntryMetadata,
+        module: scalecodec.ScaleInfoPalletMetadata,
         spec_version_id: int,
         runtime: Optional[Runtime] = None,
     ) -> dict:
@@ -1026,7 +1026,7 @@ class SubstrateMixin(ABC):
     @staticmethod
     def _get_metadata_call_function(
         module_name: str, call_function_name: str, runtime: Runtime
-    ):
+    ) -> Optional[scalecodec.GenericVariant]:
         """
         See subclass `get_metadata_call_function` for documentation.
         """
@@ -1037,8 +1037,7 @@ class SubstrateMixin(ABC):
                         return call
         return None
 
-    @staticmethod
-    def _get_metadata_events(runtime: Runtime) -> list[dict]:
+    def _get_metadata_events(self, runtime: Runtime) -> list[dict]:
         """
         See subclass `get_metadata_events` for documentation.
         """
@@ -1054,7 +1053,9 @@ class SubstrateMixin(ABC):
         return event_list
 
     @staticmethod
-    def _get_metadata_event(runtime: Runtime) -> Optional[Any]:
+    def _get_metadata_event(
+        module_name: str, event_name: str, runtime: Runtime
+    ) -> Optional[scalecodec.GenericScaleInfoEvent]:
         """
         See subclass `get_metadata_event` for documentation.
         """
@@ -1065,8 +1066,7 @@ class SubstrateMixin(ABC):
                         return event
         return None
 
-    @staticmethod
-    def _get_metadata_constants(runtime: Runtime) -> list[dict]:
+    def _get_metadata_constants(self, runtime: Runtime) -> list[dict]:
         """
         See subclass `get_metadata_constants` for documentation.
         """
@@ -1083,7 +1083,7 @@ class SubstrateMixin(ABC):
     @staticmethod
     def _get_metadata_constant(
         module_name: str, constant_name: str, runtime: Runtime
-    ) -> Optional[dict]:
+    ) -> Optional[scalecodec.ScaleInfoModuleConstantMetadata]:
         """
         See subclass `get_metadata_constant` for documentation.
         """
@@ -1114,8 +1114,7 @@ class SubstrateMixin(ABC):
             for idx, module in enumerate(runtime.metadata.pallets)
         ]
 
-    @staticmethod
-    def _get_metadata_storage_functions(runtime: Runtime) -> list:
+    def _get_metadata_storage_functions(self, runtime: Runtime) -> list[dict[str, Any]]:
         """
         See subclass `get_metadata_storage_functions` for documentation.
         """
@@ -1129,13 +1128,13 @@ class SubstrateMixin(ABC):
                             storage_item=storage,
                             module=module,
                             spec_version_id=self.runtime.runtime_version,
+                            runtime=runtime,
                         )
                     )
 
         return storage_list
 
-    @staticmethod
-    def _get_metadata_errors(runtime: Runtime) -> list[dict[str, Optional[str]]]:
+    def _get_metadata_errors(self, runtime: Runtime) -> list[dict[str, Optional[str]]]:
         """
         See subclass `get_metadata_errors` for documentation.
         """
@@ -1157,7 +1156,7 @@ class SubstrateMixin(ABC):
     @staticmethod
     def _get_metadata_error(
         module_name: str, error_name: str, runtime: Runtime
-    ) -> Optional[ScaleType]:
+    ) -> Optional[scalecodec.GenericVariant]:
         """
         See subclass `get_metadata_error` for documentation.
         """
@@ -1171,7 +1170,7 @@ class SubstrateMixin(ABC):
     @staticmethod
     def _get_metadata_runtime_call_function(
         api: str, method: str, runtime: Runtime
-    ) -> scalecodec.ScaleType:
+    ) -> scalecodec.GenericRuntimeCallDefinition:
         """
         See subclass `get_metadata_runtime_call_function` for documentation.
         """
@@ -1198,7 +1197,7 @@ class SubstrateMixin(ABC):
 
     def _get_metadata_runtime_call_functions(
         self, runtime: Runtime
-    ) -> list[scalecodec.ScaleType]:
+    ) -> list[scalecodec.GenericRuntimeCallDefinition]:
         """
         See subclass `get_metadata_runtime_call_functions` for documentation.
         """


### PR DESCRIPTION
Since creating the new `Runtime` objects, we use these directly to query the metadata. Therefore it's proper to move all `get_metadata_*` methods to `SubstrateMixin`.

The only exception is `get_metadata_storage_function` because it's already just two lines.

Also updated type annotations for all of these.