### PR TITLE
Changelog + version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+## 1.5.10 /2025-11-12
+* bug fixes 1.5.10 by @thewhaleking in https://github.com/opentensor/async-substrate-interface/pull/231
+  * no double-sleep in async-substrate-interface websocket querying
+  * KeyError catching on websocket race conditions
+  * corrected state check on disconnecting
+  * reset ws attempts on close
+
+**Full Changelog**: https://github.com/opentensor/async-substrate-interface/compare/v1.5.9...v1.5.10
+
 ## 1.5.9 /2025-10-29
 * Adds metadata call functions retrieval by @thewhaleking in https://github.com/opentensor/async-substrate-interface/pull/223
 * move metadata methods to SubstrateMixin by @thewhaleking in https://github.com/opentensor/async-substrate-interface/pull/224

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "async-substrate-interface"
-version = "1.5.9"
+version = "1.5.10"
 description = "Asyncio library for interacting with substrate. Mostly API-compatible with py-substrate-interface"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## 1.5.10 /2025-11-12
* bug fixes 1.5.10 by @thewhaleking in https://github.com/opentensor/async-substrate-interface/pull/231
  * no double-sleep in async-substrate-interface websocket querying
  * KeyError catching on websocket race conditions
  * corrected state check on disconnecting
  * reset ws attempts on close

**Full Changelog**: https://github.com/opentensor/async-substrate-interface/compare/v1.5.9...v1.5.10
