### PR TITLE
Ensure events same between get_events and ExtrinsicReceipt.triggered_events

### DIFF
--- a/tests/integration_tests/test_async_substrate_interface_integration.py
+++ b/tests/integration_tests/test_async_substrate_interface_integration.py
@@ -11,7 +11,11 @@ import pytest
 import pytest_asyncio
 from scalecodec import ss58_encode
 
-from async_substrate_interface.async_substrate import AsyncSubstrateInterface, logger
+from async_substrate_interface.async_substrate import (
+    AsyncSubstrateInterface,
+    AsyncExtrinsicReceipt,
+    logger,
+)
 from tests.helpers.settings import ARCHIVE_ENTRYPOINT, LATENT_LITE_ENTRYPOINT
 from tests.helpers.proxy_server import ProxyServer
 
@@ -918,3 +922,16 @@ async def test_bits(substrate):
         params=[71],
     )
     assert isinstance(current_sqrt_price.value, dict)
+
+
+async def test_same_events(substrate: AsyncSubstrateInterface):
+    block_hash = await substrate.get_chain_finalised_head()
+    block = await substrate.get_block_number(block_hash)
+    ext_idx = 1
+    events = await substrate.get_events(block_hash=block_hash)
+    ext_receipt = await AsyncExtrinsicReceipt.create_from_extrinsic_identifier(
+        substrate, f"{block}-{ext_idx}"
+    )
+    ext_events = await ext_receipt.triggered_events
+    events_for_ext = [e for e in events if e["extrinsic_idx"] == ext_idx]
+    assert ext_events == events_for_ext

--- a/tests/integration_tests/test_substrate_interface_integration.py
+++ b/tests/integration_tests/test_substrate_interface_integration.py
@@ -2,7 +2,10 @@ import bittensor_wallet
 import pytest
 from scalecodec import ss58_encode
 
-from async_substrate_interface.sync_substrate import SubstrateInterface
+from async_substrate_interface.sync_substrate import (
+    SubstrateInterface,
+    ExtrinsicReceipt,
+)
 from tests.helpers.settings import ARCHIVE_ENTRYPOINT
 
 
@@ -731,3 +734,16 @@ def test_bits(substrate):
         params=[71],
     )
     assert isinstance(current_sqrt_price.value, dict)
+
+
+def test_same_events(substrate: SubstrateInterface):
+    block_hash = substrate.get_chain_finalised_head()
+    block = substrate.get_block_number(block_hash)
+    ext_idx = 1
+    events = substrate.get_events(block_hash=block_hash)
+    ext_receipt = ExtrinsicReceipt.create_from_extrinsic_identifier(
+        substrate, f"{block}-{ext_idx}"
+    )
+    ext_events = ext_receipt.triggered_events
+    events_for_ext = [e for e in events if e["extrinsic_idx"] == ext_idx]
+    assert ext_events == events_for_ext


### PR DESCRIPTION
Adds test to ensure events are the same from extrinsic receipt and for get_events (same type, same events)