### PR TITLE
Remove `query_multiple`

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -2702,7 +2702,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         runtime: Optional[Runtime] = None,
     ) -> Any:
         """
-        Makes an RPC request to the subtensor. Use this only if `self.query` and `self.query_multiple` and
+        Makes an RPC request to the subtensor. Use this only if `self.query` and `self.query_multi` and
         `self.query_map` do not meet your needs.
 
         Args:
@@ -3669,7 +3669,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
     ) -> Optional[ScaleType[Any]]:
         """
         Queries substrate. This should only be used when making a single request. For multiple requests,
-        you should use `self.query_multiple`
+        you should use `self.query_multi`
         """
         block_hash = await self._get_current_block_hash(block_hash, reuse_block_hash)
         if block_hash:

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -2848,49 +2848,6 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
         return call
 
-    async def query_multiple(
-        self,
-        params: list,
-        storage_function: str,
-        module: str,
-        block_hash: Optional[str] = None,
-        reuse_block_hash: bool = False,
-        runtime: Optional[Runtime] = None,
-    ) -> dict[str, ScaleType]:
-        """
-        Queries the subtensor. Only use this when making multiple queries, else use ``self.query``
-        """
-        # By allowing for specifying the block hash, users, if they have multiple query types they want
-        # to do, can simply query the block hash first, and then pass multiple query_subtensor calls
-        # into an asyncio.gather, with the specified block hash
-        block_hash = await self._get_current_block_hash(block_hash, reuse_block_hash)
-        if block_hash:
-            self.last_block_hash = block_hash
-        if runtime is None:
-            runtime = await self.init_runtime(block_hash=block_hash)
-        preprocessed: tuple[Preprocessed] = await asyncio.gather(
-            *[
-                self._preprocess(
-                    [x], block_hash, storage_function, module, runtime=runtime
-                )
-                for x in params
-            ]
-        )
-        all_info = [
-            self.make_payload(item.queryable, item.method, item.params)
-            for item in preprocessed
-        ]
-        # These will always be the same throughout the preprocessed list, so we just grab the first one
-        value_scale_type = preprocessed[0].value_scale_type
-        storage_item = preprocessed[0].storage_item
-
-        responses = await self._make_rpc_request(
-            all_info, value_scale_type, storage_item, runtime=runtime
-        )
-        return {
-            param: responses[p.queryable][0] for (param, p) in zip(params, preprocessed)
-        }
-
     async def query_multi(
         self,
         storage_keys: list[StorageKey],

--- a/async_substrate_interface/substrate_addons.py
+++ b/async_substrate_interface/substrate_addons.py
@@ -63,7 +63,6 @@ RETRY_METHODS = [
     "query",
     "query_map",
     "query_multi",
-    "query_multiple",
     "retrieve_extrinsic_by_identifier",
     "rpc_request",
     "runtime_call",

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -1991,38 +1991,6 @@ class SubstrateInterface(SubstrateMixin):
 
         return call
 
-    def query_multiple(
-        self,
-        params: list,
-        storage_function: str,
-        module: str,
-        block_hash: Optional[str] = None,
-        reuse_block_hash: bool = False,
-    ) -> dict[str, ScaleType]:
-        """
-        Queries the subtensor. Only use this when making multiple queries, else use ``self.query``
-        """
-        block_hash = self._get_current_block_hash(block_hash, reuse_block_hash)
-        if block_hash:
-            self.last_block_hash = block_hash
-        self.init_runtime(block_hash=block_hash)
-
-        preprocessed: list[Preprocessed] = [
-            self._preprocess([x], block_hash, storage_function, module) for x in params
-        ]
-        all_info = [
-            self.make_payload(item.queryable, item.method, item.params)
-            for item in preprocessed
-        ]
-        # These will always be the same throughout the preprocessed list, so we just grab the first one
-        value_scale_type = preprocessed[0].value_scale_type
-        storage_item = preprocessed[0].storage_item
-
-        responses = self._make_rpc_request(all_info, value_scale_type, storage_item)
-        return {
-            param: responses[p.queryable][0] for (param, p) in zip(params, preprocessed)
-        }
-
     def query_multi(
         self, storage_keys: list[StorageKey], block_hash: Optional[str] = None
     ) -> list[tuple[StorageKey, Any]]:

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -1657,7 +1657,7 @@ class SubstrateInterface(SubstrateMixin):
                 pallet=module,
                 storage_function=storage_function,
                 value_scale_type=value_scale_type,
-                metadata=self.metadata,
+                metadata=self.runtime.metadata,
                 runtime_config=self.runtime_config,
             )
         else:

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -1869,7 +1869,7 @@ class SubstrateInterface(SubstrateMixin):
         reuse_block_hash: bool = False,
     ) -> Any:
         """
-        Makes an RPC request to the subtensor. Use this only if `self.query` and `self.query_multiple` and
+        Makes an RPC request to the subtensor. Use this only if `self.query` and `self.query_multi` and
         `self.query_map` do not meet your needs.
 
         Args:
@@ -2725,7 +2725,7 @@ class SubstrateInterface(SubstrateMixin):
     ) -> Optional[ScaleType[Any]]:
         """
         Queries substrate. This should only be used when making a single request. For multiple requests,
-        you should use ``self.query_multiple``
+        you should use `self.query_multi`
         """
         block_hash = self._get_current_block_hash(block_hash, reuse_block_hash)
         if block_hash:

--- a/tests/integration_tests/test_async_substrate_interface_integration.py
+++ b/tests/integration_tests/test_async_substrate_interface_integration.py
@@ -148,25 +148,6 @@ async def test_get_events_proper_decoding(substrate):
 
 
 @pytest.mark.asyncio
-async def test_query_multiple(substrate):
-    print("Testing test_query_multiple")
-    block = 6153277
-    cks = [
-        "5FH9AQM4kqbkdC9jyV5FrdEWVYt41nkhFstop7Vhyfb9ZsXt",
-        "5GQxLKxjZWNZDsghmYcw7P6ahC7XJCjx1WD94WGh92quSycx",
-        "5EcaPiDT1cv951SkCFsvdHDs2yAEUWhJDuRP9mHb343WnaVn",
-    ]
-    block_hash = await substrate.get_block_hash(block_id=block)
-    assert await substrate.query_multiple(
-        params=cks,
-        module="SubtensorModule",
-        storage_function="OwnedHotkeys",
-        block_hash=block_hash,
-    )
-    print("test_query_multiple succeeded")
-
-
-@pytest.mark.asyncio
 async def test_reconnection():
     """
     Does not use the substrate fixture because this needs to reconnect

--- a/tests/integration_tests/test_substrate_interface_integration.py
+++ b/tests/integration_tests/test_substrate_interface_integration.py
@@ -86,24 +86,6 @@ def test_get_events_proper_decoding(substrate):
     print("test_get_events_proper_decoding succeeded")
 
 
-def test_query_multiple(substrate):
-    print("Testing test_query_multiple")
-    block = 6153277
-    cks = [
-        "5FH9AQM4kqbkdC9jyV5FrdEWVYt41nkhFstop7Vhyfb9ZsXt",
-        "5GQxLKxjZWNZDsghmYcw7P6ahC7XJCjx1WD94WGh92quSycx",
-        "5EcaPiDT1cv951SkCFsvdHDs2yAEUWhJDuRP9mHb343WnaVn",
-    ]
-    block_hash = substrate.get_block_hash(block_id=block)
-    assert substrate.query_multiple(
-        params=cks,
-        module="SubtensorModule",
-        storage_function="OwnedHotkeys",
-        block_hash=block_hash,
-    )
-    print("test_query_multiple succeeded")
-
-
 def test_query_map_with_odd_number_of_params(substrate):
     print("Testing test_query_map_with_odd_number_of_params")
     qm = substrate.query_map(


### PR DESCRIPTION
Closes #292 

Removes a method that made sense at one point, but no longer does.