### PR TITLE
runtime call inconsistent return type

### DIFF
--- a/.github/workflows/check-scalecodec-conflict.yml
+++ b/.github/workflows/check-scalecodec-conflict.yml
@@ -4,7 +4,7 @@ permissions:
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened, edited, ready_for_review]
 
 jobs:
   check-scalecodec-conflict:

--- a/.github/workflows/unit-and-integration-test.yml
+++ b/.github/workflows/unit-and-integration-test.yml
@@ -4,7 +4,7 @@ permissions:
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened, edited, ready_for_review]
 
 jobs:
   unit-and-integration-tests:

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -3423,9 +3423,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
         # Decode result
         result_bytes = hex_to_bytes(result_data["result"])
-        obj = await self.decode_scale(output_type_string, result_bytes, runtime=runtime)
-        obj.decode()
-        return obj
+        return await self.decode_scale(output_type_string, result_bytes, runtime=runtime)
 
     async def get_account_nonce(self, account_address: str) -> int:
         """

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -1695,7 +1695,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                     )
 
                     subscription_result = await subscription_handler(
-                        storage_key, updated_obj, subscription_id
+                        storage_key, updated_obj.value, subscription_id
                     )
 
                     if subscription_result is not None:
@@ -3263,9 +3263,12 @@ class AsyncSubstrateInterface(SubstrateMixin):
         if "error" in result_data:
             raise SubstrateRequestException(result_data["error"]["message"])
         result_vec_u8_bytes = hex_to_bytes(result_data["result"])
-        result_bytes = await self.decode_scale(
-            "Vec<u8>", result_vec_u8_bytes, runtime=runtime
-        )
+        result_bytes = (
+            await self.decode_scale("Vec<u8>", result_vec_u8_bytes, runtime=runtime)
+        ).value
+
+        # TODO check to see if we can use the bytes from the ScaleType rather than using the value
+        # TODO and then re-encoding as bytes
 
         # Decode result
         # Get correct type
@@ -3356,7 +3359,9 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
         # Decode result
         result_bytes = hex_to_bytes(result_data["result"])
-        return await self.decode_scale(output_type_string, result_bytes, runtime=runtime)
+        obj = await self.decode_scale(output_type_string, result_bytes, runtime=runtime)
+        # protect against `None`s from decode_scale
+        return getattr(obj, "value", obj)
 
     async def get_account_nonce(self, account_address: str) -> int:
         """
@@ -3542,7 +3547,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
             "TransactionPaymentApi", "query_info", [extrinsic, extrinsic_len]
         )
 
-        return result.value
+        return result
 
     async def get_type_registry(
         self, block_hash: Optional[str] = None, max_recursion: int = 4

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -1450,7 +1450,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         scale_bytes: bytes,
         block_hash: Optional[str] = None,
         runtime: Optional[Runtime] = None,
-    ) -> Optional[ScaleType[Any] | Any]:
+    ) -> Optional[ScaleType[Any]]:
         """
         Helper function to decode arbitrary SCALE-bytes (e.g. 0x02000000) according to given RUST type_string
         (e.g. BlockNumber). The relevant versioning information of the type (if defined) will be applied if block_hash
@@ -3423,9 +3423,9 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
         # Decode result
         result_bytes = hex_to_bytes(result_data["result"])
-        return await self.decode_scale(
-            output_type_string, result_bytes, runtime=runtime
-        )
+        obj = await self.decode_scale(output_type_string, result_bytes, runtime=runtime)
+        obj.decode()
+        return obj
 
     async def get_account_nonce(self, account_address: str) -> int:
         """

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -2437,7 +2437,7 @@ class SubstrateInterface(SubstrateMixin):
         method: str,
         params: Optional[list | dict] = None,
         block_hash: Optional[str] = None,
-    ) -> ScaleType[Any]:
+    ) -> Any:
         """
         Calls a runtime API method
 
@@ -2448,7 +2448,7 @@ class SubstrateInterface(SubstrateMixin):
             block_hash: Hash of the block at which to make the runtime API call
 
         Returns:
-             ScaleType from the runtime call
+             Decoded runtime call
         """
         runtime = self.init_runtime(block_hash=block_hash)
 
@@ -2503,7 +2503,9 @@ class SubstrateInterface(SubstrateMixin):
 
         # Decode result
         result_bytes = hex_to_bytes(result_data["result"])
-        return self.decode_scale(output_type_string, result_bytes)
+        obj = self.decode_scale(output_type_string, result_bytes)
+        obj.decode()
+        return obj
 
     def get_account_nonce(self, account_address: str) -> int:
         """

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -2503,9 +2503,7 @@ class SubstrateInterface(SubstrateMixin):
 
         # Decode result
         result_bytes = hex_to_bytes(result_data["result"])
-        obj = self.decode_scale(output_type_string, result_bytes)
-        obj.decode()
-        return obj
+        return self.decode_scale(output_type_string, result_bytes)
 
     def get_account_nonce(self, account_address: str) -> int:
         """

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -920,7 +920,7 @@ class SubstrateInterface(SubstrateMixin):
                     updated_obj = self.decode_scale(
                         type_string=change_scale_type,
                         scale_bytes=hex_to_bytes(change_data),
-                    )
+                    ).value
 
                     subscription_result = subscription_handler(
                         storage_key, updated_obj, subscription_id
@@ -2338,7 +2338,7 @@ class SubstrateInterface(SubstrateMixin):
         method: str,
         params: Optional[list | dict] = None,
         block_hash: Optional[str] = None,
-    ) -> ScaleType[Any]:
+    ) -> Any:
         logger.debug(
             f"Decoding old runtime call: {api}.{method} with params: {params} at block hash: {block_hash}"
         )
@@ -2361,7 +2361,7 @@ class SubstrateInterface(SubstrateMixin):
             "state_call", [f"{api}_{method}", param_hex, block_hash]
         )
         result_vec_u8_bytes = hex_to_bytes(result_data["result"])
-        result_bytes = self.decode_scale("Vec<u8>", result_vec_u8_bytes)
+        result_bytes = self.decode_scale("Vec<u8>", result_vec_u8_bytes).value
 
         # Decode result
         # Get correct type
@@ -2444,7 +2444,9 @@ class SubstrateInterface(SubstrateMixin):
 
         # Decode result
         result_bytes = hex_to_bytes(result_data["result"])
-        return self.decode_scale(output_type_string, result_bytes)
+        obj = self.decode_scale(output_type_string, result_bytes)
+        # protect against `None`s from decode_scale
+        return getattr(obj, "value", obj)
 
     def get_account_nonce(self, account_address: str) -> int:
         """
@@ -2598,7 +2600,7 @@ class SubstrateInterface(SubstrateMixin):
             "TransactionPaymentApi", "query_info", [extrinsic, extrinsic_len]
         )
 
-        return result.value
+        return result
 
     def get_type_registry(
         self, block_hash: Optional[str] = None, max_recursion: int = 4

--- a/async_substrate_interface/utils/decoding.py
+++ b/async_substrate_interface/utils/decoding.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Any
 
 from scalecodec import ScaleBytes
 from scalecodec.base import ScaleType
@@ -150,7 +150,7 @@ def decode_query_map(
 
 def scale_decode(
     type_string: str, scale_bytes: str | bytes | ScaleBytes, runtime: "Runtime"
-) -> ScaleType:
+) -> Any:
     if isinstance(scale_bytes, (str, bytes)):
         scale_bytes = ScaleBytes(scale_bytes)
 
@@ -160,4 +160,4 @@ def scale_decode(
 
     obj.decode(check_remaining=runtime.config.get("strict_scale_decode"))
 
-    return obj
+    return obj.value

--- a/async_substrate_interface/utils/decoding.py
+++ b/async_substrate_interface/utils/decoding.py
@@ -149,8 +149,17 @@ def decode_query_map(
 
 
 def scale_decode(
-    type_string: str, scale_bytes: str | bytes | ScaleBytes, runtime: "Runtime"
-) -> Any:
+    type_string: str,
+    scale_bytes: str | bytes | ScaleBytes,
+    runtime: "Runtime",
+) -> ScaleType[Any]:
+    """
+    Decodes a scale bytes using a type string and a Runtime object.
+
+    Returns:
+        The decoded Scale object as a ScaleType
+    """
+
     if isinstance(scale_bytes, (str, bytes)):
         scale_bytes = ScaleBytes(scale_bytes)
 
@@ -159,5 +168,4 @@ def scale_decode(
     )
 
     obj.decode(check_remaining=runtime.config.get("strict_scale_decode"))
-
-    return obj.value
+    return obj

--- a/tests/integration_tests/test_async_substrate_interface_integration.py
+++ b/tests/integration_tests/test_async_substrate_interface_integration.py
@@ -352,7 +352,7 @@ async def test_old_runtime_calls_natively(substrate):
         params=[coldkey_ss58],
         block_hash=new_block_hash,
     )
-    assert result.value == [
+    assert result == [
         {
             "hotkey": "5CsvRJXuR955WojnGMdok1hbhffZyB4N5ocrv82f3p5A2zVp",
             "coldkey": "5CQ6dMW8JZhKCZX9kWsZRqa3kZRKmNHxbPPVFEt6FgyvGv2G",

--- a/tests/integration_tests/test_substrate_interface_integration.py
+++ b/tests/integration_tests/test_substrate_interface_integration.py
@@ -165,7 +165,7 @@ def test_old_runtime_calls_natively(substrate):
         params=[coldkey_ss58],
         block_hash=new_block_hash,
     )
-    assert result.value == [
+    assert result == [
         {
             "hotkey": "5CsvRJXuR955WojnGMdok1hbhffZyB4N5ocrv82f3p5A2zVp",
             "coldkey": "5CQ6dMW8JZhKCZX9kWsZRqa3kZRKmNHxbPPVFEt6FgyvGv2G",

--- a/tests/unit_tests/asyncio_/test_substrate_interface_async_unit.py
+++ b/tests/unit_tests/asyncio_/test_substrate_interface_async_unit.py
@@ -49,7 +49,9 @@ async def test_runtime_call(monkeypatch):
     substrate.encode_scale = AsyncMock()
 
     # Patch decode_scale to produce a dummy value
-    substrate.decode_scale = AsyncMock(return_value="decoded_result")
+    mock_scale_obj = MagicMock()
+    mock_scale_obj.value = "decoded_result"
+    substrate.decode_scale = AsyncMock(return_value=mock_scale_obj)
 
     # Patch RPC request with correct behavior
     substrate.rpc_request = AsyncMock(

--- a/tests/unit_tests/sync/test_substrate_interface_sync_unit.py
+++ b/tests/unit_tests/sync/test_substrate_interface_sync_unit.py
@@ -26,7 +26,9 @@ def test_runtime_call(monkeypatch):
     substrate.encode_scale = MagicMock()
 
     # Patch decode_scale to produce a dummy value
-    substrate.decode_scale = MagicMock(return_value="decoded_result")
+    mock_scale_obj = MagicMock()
+    mock_scale_obj.value = "decoded_result"
+    substrate.decode_scale = MagicMock(return_value=mock_scale_obj)
 
     # Patch RPC request with correct behavior
     substrate.rpc_request = MagicMock(


### PR DESCRIPTION
Keeps consistency between modern and legacy runtime calls.

This was missed earlier as the value printed correctly (like `843824342`), but was actually of type `primitive_U32`