### PR TITLE
Remove `query_multiple`

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -2860,7 +2860,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         runtime: Optional[Runtime] = None,
     ) -> Any:
         """
-        Makes an RPC request to the subtensor. Use this only if `self.query` and `self.query_multiple` and
+        Makes an RPC request to the subtensor. Use this only if `self.query` and
         `self.query_map` do not meet your needs.
 
         Args:
@@ -3005,49 +3005,6 @@ class AsyncSubstrateInterface(SubstrateMixin):
         )
 
         return call
-
-    async def query_multiple(
-        self,
-        params: list,
-        storage_function: str,
-        module: str,
-        block_hash: Optional[str] = None,
-        reuse_block_hash: bool = False,
-        runtime: Optional[Runtime] = None,
-    ) -> dict[str, ScaleType]:
-        """
-        Queries the subtensor. Only use this when making multiple queries, else use ``self.query``
-        """
-        # By allowing for specifying the block hash, users, if they have multiple query types they want
-        # to do, can simply query the block hash first, and then pass multiple query_subtensor calls
-        # into an asyncio.gather, with the specified block hash
-        block_hash = await self._get_current_block_hash(block_hash, reuse_block_hash)
-        if block_hash:
-            self.last_block_hash = block_hash
-        if runtime is None:
-            runtime = await self.init_runtime(block_hash=block_hash)
-        preprocessed: tuple[Preprocessed] = await asyncio.gather(
-            *[
-                self._preprocess(
-                    [x], block_hash, storage_function, module, runtime=runtime
-                )
-                for x in params
-            ]
-        )
-        all_info = [
-            self.make_payload(item.queryable, item.method, item.params)
-            for item in preprocessed
-        ]
-        # These will always be the same throughout the preprocessed list, so we just grab the first one
-        value_scale_type = preprocessed[0].value_scale_type
-        storage_item = preprocessed[0].storage_item
-
-        responses = await self._make_rpc_request(
-            all_info, value_scale_type, storage_item, runtime=runtime
-        )
-        return {
-            param: responses[p.queryable][0] for (param, p) in zip(params, preprocessed)
-        }
 
     async def query_multi(
         self,
@@ -3882,7 +3839,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
     ) -> Optional[Union["ScaleObj", Any]]:
         """
         Queries substrate. This should only be used when making a single request. For multiple requests,
-        you should use `self.query_multiple`
+        you should use `self.query_multi`
         """
         block_hash = await self._get_current_block_hash(block_hash, reuse_block_hash)
         if block_hash:

--- a/async_substrate_interface/substrate_addons.py
+++ b/async_substrate_interface/substrate_addons.py
@@ -63,7 +63,6 @@ RETRY_METHODS = [
     "query",
     "query_map",
     "query_multi",
-    "query_multiple",
     "retrieve_extrinsic_by_identifier",
     "rpc_request",
     "runtime_call",

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -2024,7 +2024,7 @@ class SubstrateInterface(SubstrateMixin):
         reuse_block_hash: bool = False,
     ) -> Any:
         """
-        Makes an RPC request to the subtensor. Use this only if `self.query` and `self.query_multiple` and
+        Makes an RPC request to the subtensor. Use this only if `self.query` and
         `self.query_map` do not meet your needs.
 
         Args:
@@ -2145,38 +2145,6 @@ class SubstrateInterface(SubstrateMixin):
         )
 
         return call
-
-    def query_multiple(
-        self,
-        params: list,
-        storage_function: str,
-        module: str,
-        block_hash: Optional[str] = None,
-        reuse_block_hash: bool = False,
-    ) -> dict[str, ScaleType]:
-        """
-        Queries the subtensor. Only use this when making multiple queries, else use ``self.query``
-        """
-        block_hash = self._get_current_block_hash(block_hash, reuse_block_hash)
-        if block_hash:
-            self.last_block_hash = block_hash
-        self.init_runtime(block_hash=block_hash)
-
-        preprocessed: tuple[Preprocessed] = [
-            self._preprocess([x], block_hash, storage_function, module) for x in params
-        ]
-        all_info = [
-            self.make_payload(item.queryable, item.method, item.params)
-            for item in preprocessed
-        ]
-        # These will always be the same throughout the preprocessed list, so we just grab the first one
-        value_scale_type = preprocessed[0].value_scale_type
-        storage_item = preprocessed[0].storage_item
-
-        responses = self._make_rpc_request(all_info, value_scale_type, storage_item)
-        return {
-            param: responses[p.queryable][0] for (param, p) in zip(params, preprocessed)
-        }
 
     def query_multi(
         self, storage_keys: list[StorageKey], block_hash: Optional[str] = None
@@ -2926,7 +2894,7 @@ class SubstrateInterface(SubstrateMixin):
     ) -> Optional[Union["ScaleObj", Any]]:
         """
         Queries substrate. This should only be used when making a single request. For multiple requests,
-        you should use ``self.query_multiple``
+        you should use ``self.query_multi``
         """
         block_hash = self._get_current_block_hash(block_hash, reuse_block_hash)
         if block_hash:

--- a/tests/integration_tests/test_async_substrate_interface.py
+++ b/tests/integration_tests/test_async_substrate_interface.py
@@ -149,26 +149,6 @@ async def test_get_events_proper_decoding():
 
 
 @pytest.mark.asyncio
-async def test_query_multiple():
-    print("Testing test_query_multiple")
-    block = 6153277
-    cks = [
-        "5FH9AQM4kqbkdC9jyV5FrdEWVYt41nkhFstop7Vhyfb9ZsXt",
-        "5GQxLKxjZWNZDsghmYcw7P6ahC7XJCjx1WD94WGh92quSycx",
-        "5EcaPiDT1cv951SkCFsvdHDs2yAEUWhJDuRP9mHb343WnaVn",
-    ]
-    async with AsyncSubstrateInterface(ARCHIVE_ENTRYPOINT) as substrate:
-        block_hash = await substrate.get_block_hash(block_id=block)
-        assert await substrate.query_multiple(
-            params=cks,
-            module="SubtensorModule",
-            storage_function="OwnedHotkeys",
-            block_hash=block_hash,
-        )
-    print("test_query_multiple succeeded")
-
-
-@pytest.mark.asyncio
 async def test_reconnection():
     print("Testing test_reconnection")
     async with AsyncSubstrateInterface(

--- a/tests/integration_tests/test_substrate_interface.py
+++ b/tests/integration_tests/test_substrate_interface.py
@@ -92,25 +92,6 @@ def test_get_events_proper_decoding():
     print("test_get_events_proper_decoding succeeded")
 
 
-def test_query_multiple():
-    print("Testing test_query_multiple")
-    block = 6153277
-    cks = [
-        "5FH9AQM4kqbkdC9jyV5FrdEWVYt41nkhFstop7Vhyfb9ZsXt",
-        "5GQxLKxjZWNZDsghmYcw7P6ahC7XJCjx1WD94WGh92quSycx",
-        "5EcaPiDT1cv951SkCFsvdHDs2yAEUWhJDuRP9mHb343WnaVn",
-    ]
-    with SubstrateInterface(ARCHIVE_ENTRYPOINT) as substrate:
-        block_hash = substrate.get_block_hash(block_id=block)
-        assert substrate.query_multiple(
-            params=cks,
-            module="SubtensorModule",
-            storage_function="OwnedHotkeys",
-            block_hash=block_hash,
-        )
-    print("test_query_multiple succeeded")
-
-
 def test_query_map_with_odd_number_of_params():
     print("Testing test_query_map_with_odd_number_of_params")
     with SubstrateInterface(LATENT_LITE_ENTRYPOINT, ss58_format=42) as substrate:


### PR DESCRIPTION
Closes #292

Removes the query_multiple method from both sync and async interfaces. Pointless with RuntimeCache. Updates docstrings that referenced it to point to query_multi instead.