### PR TITLE
fix: Catch timeout in RetryAsyncSubstrate

### DIFF
--- a/async_substrate_interface/substrate_addons.py
+++ b/async_substrate_interface/substrate_addons.py
@@ -347,8 +347,9 @@ class RetryAsyncSubstrate(AsyncSubstrateInterface):
         except (
             MaxRetriesExceeded,
             ConnectionError,
-            ConnectionClosed,
             EOFError,
+            ConnectionClosed,
+            TimeoutError,
             socket.gaierror,
             StateDiscardedError,
         ) as e:


### PR DESCRIPTION
Catches timeout in RetryAsyncSubstrate, the same as in RetrySyncSubstrate

Resolves #309 