### PR TITLE
type fixes

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -1463,6 +1463,8 @@ class AsyncSubstrateInterface(SubstrateMixin):
             if runtime is None:
                 runtime = await self.init_runtime(block_hash=block_hash)
             obj = scale_decode(type_string, scale_bytes, runtime=runtime)
+            if getattr(obj, "value") is None:
+                return None
             return obj
 
     async def init_runtime(
@@ -2530,7 +2532,6 @@ class AsyncSubstrateInterface(SubstrateMixin):
         storage_item: Optional[ScaleType] = None,
         result_handler: Optional[ResultHandler] = None,
         runtime: Optional[Runtime] = None,
-        force_legacy_decode: bool = False,
     ) -> tuple[Any, bool]:
         """
         Processes the RPC call response by decoding it, returning it as is, or setting a handler for subscriptions,
@@ -2543,12 +2544,11 @@ class AsyncSubstrateInterface(SubstrateMixin):
             storage_item: The ScaleType object used for decoding ScaleBytes results
             result_handler: the result handler coroutine used for handling longer-running subscriptions
             runtime: Optional Runtime to use for decoding. If not specified, the currently-loaded `self.runtime` is used
-            force_legacy_decode: Whether to force the use of the legacy Metadata V14 decoder
 
         Returns:
              (decoded response, completion)
         """
-        result: dict | ScaleType = response
+        result: Optional[dict | ScaleType] = response
         if value_scale_type and isinstance(storage_item, ScaleType):
             if (response_result := response.get("result")) is not None:
                 query_value = response_result
@@ -2566,7 +2566,6 @@ class AsyncSubstrateInterface(SubstrateMixin):
             else:
                 q = query_value
             decoded = await self.decode_scale(value_scale_type, q, runtime=runtime)
-            assert decoded is not None
             result = decoded
         if asyncio.iscoroutinefunction(result_handler):
             # For multipart responses as a result of subscriptions.
@@ -2580,9 +2579,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         value_scale_type: Optional[str] = None,
         storage_item: Optional[ScaleType] = None,
         result_handler: Optional[ResultHandler] = None,
-        attempt: int = 1,
         runtime: Optional[Runtime] = None,
-        force_legacy_decode: bool = False,
     ) -> RequestResults:
         request_manager = RequestManager(payloads)
 
@@ -2639,7 +2636,6 @@ class AsyncSubstrateInterface(SubstrateMixin):
                                 storage_item,
                                 result_handler,
                                 runtime=runtime,
-                                force_legacy_decode=force_legacy_decode,
                             )
                             request_manager.add_response(
                                 item_id, decoded_response, complete

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -1441,9 +1441,9 @@ class AsyncSubstrateInterface(SubstrateMixin):
         scale_bytes: bytes,
         block_hash: Optional[str] = None,
         runtime: Optional[Runtime] = None,
-    ) -> Optional[ScaleType[Any]]:
+    ) -> ScaleType[Any]:
         """
-        Helper function to decode arbitrary SCALE-bytes (e.g. 0x02000000) according to given RUST type_string
+        Helper function to decode arbitrary SCALE-bytes (e.g. 0x02000000) according to given type_string
         (e.g. BlockNumber). The relevant versioning information of the type (if defined) will be applied if block_hash
         is set
 
@@ -1457,15 +1457,10 @@ class AsyncSubstrateInterface(SubstrateMixin):
         Returns:
             ScaleType object
         """
-        if scale_bytes == b"":
-            return None
-        else:
-            if runtime is None:
-                runtime = await self.init_runtime(block_hash=block_hash)
-            obj = scale_decode(type_string, scale_bytes, runtime=runtime)
-            if getattr(obj, "value") is None:
-                return None
-            return obj
+        if runtime is None:
+            runtime = await self.init_runtime(block_hash=block_hash)
+        obj = scale_decode(type_string, scale_bytes, runtime=runtime)
+        return obj
 
     async def init_runtime(
         self,
@@ -1692,7 +1687,6 @@ class AsyncSubstrateInterface(SubstrateMixin):
                         scale_bytes=hex_to_bytes(change_data),
                         runtime=runtime,
                     )
-                    assert updated_obj is not None
 
                     subscription_result = await subscription_handler(
                         storage_key, updated_obj.value, subscription_id
@@ -2548,7 +2542,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         Returns:
              (decoded response, completion)
         """
-        result: Optional[dict | ScaleType] = response
+        result: dict | ScaleType = response
         if value_scale_type and isinstance(storage_item, ScaleType):
             if (response_result := response.get("result")) is not None:
                 query_value = response_result
@@ -3281,7 +3275,6 @@ class AsyncSubstrateInterface(SubstrateMixin):
         _decoded = await self.decode_scale(
             "Vec<u8>", result_vec_u8_bytes, runtime=runtime
         )
-        assert _decoded is not None
         result_bytes = _decoded.value
 
         # TODO check to see if we can use the bytes from the ScaleType rather than using the value
@@ -3377,8 +3370,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
         # Decode result
         result_bytes = hex_to_bytes(result_data["result"])
         obj = await self.decode_scale(output_type_string, result_bytes, runtime=runtime)
-        # protect against `None`s from decode_scale
-        return getattr(obj, "value", obj)
+        return obj.value
 
     async def get_account_nonce(self, account_address: str) -> int:
         """

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -707,6 +707,8 @@ class SubstrateInterface(SubstrateMixin):
         else:
             assert self.runtime is not None
             obj = scale_decode(type_string, scale_bytes, runtime=self.runtime)
+            if getattr(obj, "value") is None:
+                return None
             return obj
 
     def load_runtime(self, runtime):
@@ -1719,7 +1721,7 @@ class SubstrateInterface(SubstrateMixin):
         Returns:
              (decoded response, completion)
         """
-        result: dict | ScaleType = response
+        result: Optional[dict | ScaleType] = response
         if value_scale_type and isinstance(storage_item, ScaleType):
             if (response_result := response.get("result")) is not None:
                 query_value = response_result
@@ -1737,7 +1739,6 @@ class SubstrateInterface(SubstrateMixin):
             else:
                 q = query_value
             decoded = self.decode_scale(value_scale_type, q)
-            assert decoded is not None
             result = decoded
         if callable(result_handler):
             # For multipart responses as a result of subscriptions.

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -689,7 +689,7 @@ class SubstrateInterface(SubstrateMixin):
         self,
         type_string: str,
         scale_bytes: bytes,
-    ) -> Optional[ScaleType]:
+    ) -> ScaleType[Any]:
         """
         Helper function to decode arbitrary SCALE-bytes (e.g. 0x02000000) according to given RUST type_string
         (e.g. BlockNumber). The relevant versioning information of the type (if defined) will be applied if block_hash
@@ -702,14 +702,9 @@ class SubstrateInterface(SubstrateMixin):
         Returns:
             ScaleType object
         """
-        if scale_bytes == b"":
-            return None
-        else:
-            assert self.runtime is not None
-            obj = scale_decode(type_string, scale_bytes, runtime=self.runtime)
-            if getattr(obj, "value") is None:
-                return None
-            return obj
+        assert self.runtime is not None
+        obj = scale_decode(type_string, scale_bytes, runtime=self.runtime)
+        return obj
 
     def load_runtime(self, runtime):
         self.runtime = runtime
@@ -942,7 +937,6 @@ class SubstrateInterface(SubstrateMixin):
                         type_string=change_scale_type,
                         scale_bytes=hex_to_bytes(change_data),
                     )
-                    assert decoded is not None
                     updated_obj = decoded.value
 
                     subscription_result = subscription_handler(
@@ -2404,7 +2398,6 @@ class SubstrateInterface(SubstrateMixin):
         )
         result_vec_u8_bytes = hex_to_bytes(result_data["result"])
         _decoded = self.decode_scale("Vec<u8>", result_vec_u8_bytes)
-        assert _decoded is not None
         result_bytes = _decoded.value
 
         # Decode result
@@ -2490,7 +2483,7 @@ class SubstrateInterface(SubstrateMixin):
         result_bytes = hex_to_bytes(result_data["result"])
         obj = self.decode_scale(output_type_string, result_bytes)
         # protect against `None`s from decode_scale
-        return getattr(obj, "value", obj)
+        return obj.value
 
     def get_account_nonce(self, account_address: str) -> int:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ keywords = ["substrate", "development", "bittensor"]
 dependencies = [
   "wheel",
   "aiosqlite>=0.21.0,<1.0.0",
-  "cyscale==0.1.11",
+  "cyscale==0.2.0",
   "websockets>=14.1",
   "xxhash",
   "ruff==0.11.5",


### PR DESCRIPTION
Ensures that things like `query` always return `ScaleType` instead of `Optional[ScaleType]`