### PR TITLE
Fix an issue where the retry could lock up

### DIFF
--- a/async_substrate_interface/substrate_addons.py
+++ b/async_substrate_interface/substrate_addons.py
@@ -319,6 +319,15 @@ class RetryAsyncSubstrate(AsyncSubstrateInterface):
             )
         else:
             logger.error(f"Connection error. Trying again with {next_network}")
+        if (
+            self.startup_runtime_task is not None
+            and not self.startup_runtime_task.done()
+        ):
+            self.startup_runtime_task.cancel()
+            try:
+                await self.startup_runtime_task
+            except asyncio.CancelledError:
+                pass
         try:
             await self.ws.shutdown()
         except AttributeError:

--- a/async_substrate_interface/utils/cache.py
+++ b/async_substrate_interface/utils/cache.py
@@ -489,6 +489,8 @@ class CachedFetcher:
             raise
         finally:
             self._inflight.pop(key, None)
+            if not future.done():
+                future.cancel()
 
 
 class _WeakMethod:


### PR DESCRIPTION
When `_reinstantiate_substrate` is triggered (e.g., by `StateDiscardedError` on an old block), it calls `ws.shutdown()` which cancels the WebSocket's send/recv task. The startup_runtime_task (Task A) running in the background may have already called get_runtime_for_version(V, ...) and created a future F_A in `CachedFetcher._inflight[V]`. After shutdown, Task A's _make_rpc_request enters an infinite spin loop (`while True: ... await asyncio.sleep(0.01)`) because `ws.retrieve()` silently returns None when _send_recv_task is cancelled. F_A is never resolved, and the retry's `await get_runtime_for_version(V, ...)` hangs forever waiting on F_A. 