### PR TITLE
use cyscale 0.3.1

### DIFF
--- a/async_substrate_interface/utils/cache.py
+++ b/async_substrate_interface/utils/cache.py
@@ -271,9 +271,9 @@ class AsyncSqliteDB:
         block_hash_mapping: OrderedDict[str, int] = OrderedDict()
         version_mapping: OrderedDict[int, dict] = OrderedDict()
         tables: dict[str, OrderedDict] = {
-            "RuntimeCache_blocks_v3": block_mapping,
-            "RuntimeCache_block_hashes_v3": block_hash_mapping,
-            "RuntimeCache_versions_v3": version_mapping,
+            "RuntimeCache_blocks_v4": block_mapping,
+            "RuntimeCache_block_hashes_v4": block_hash_mapping,
+            "RuntimeCache_versions_v4": version_mapping,
         }
         for table in tables.keys():
             async with self._lock:
@@ -314,9 +314,9 @@ class AsyncSqliteDB:
                 self._db = await _async_connect()
 
             tables = {
-                "RuntimeCache_blocks_v3": block_mapping,
-                "RuntimeCache_block_hashes_v3": block_hash_mapping,
-                "RuntimeCache_versions_v3": version_mapping,
+                "RuntimeCache_blocks_v4": block_mapping,
+                "RuntimeCache_block_hashes_v4": block_hash_mapping,
+                "RuntimeCache_versions_v4": version_mapping,
             }
             for table, mapping in tables.items():
                 local_chain = await self._create_if_not_exists(chain, table)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ keywords = ["substrate", "development", "bittensor"]
 dependencies = [
     "wheel",
     "aiosqlite>=0.21.0,<1.0.0",
-    "cyscale>=0.3.0,<1.0.0",
+    "cyscale>=0.3.1,<1.0.0",
     "websockets>=14.1",
     "xxhash",
 ]

--- a/tests/unit_tests/test_types.py
+++ b/tests/unit_tests/test_types.py
@@ -76,7 +76,7 @@ async def test_runtime_cache_from_disk():
         # insert some fake data into our DB
         conn = sqlite3.connect(test_db_location)
         conn.execute(
-            "INSERT INTO RuntimeCache_blocks_v3 (key, value, chain) VALUES (?, ?, ?)",
+            "INSERT INTO RuntimeCache_blocks_v4 (key, value, chain) VALUES (?, ?, ?)",
             (fake_block, pickle.dumps(fake_hash), fake_chain),
         )
         conn.commit()
@@ -94,7 +94,7 @@ async def test_runtime_cache_from_disk():
         # verify that our added item is now in the DB
         conn = sqlite3.connect(test_db_location)
         cursor = conn.cursor()
-        cursor.execute("SELECT key, value, chain FROM RuntimeCache_blocks_v3")
+        cursor.execute("SELECT key, value, chain FROM RuntimeCache_blocks_v4")
         query = cursor.fetchall()
         cursor.close()
         conn.close()


### PR DESCRIPTION
Uses cyscale 0.3.1 which resolves an odd pickling/unpickling issue with the metadata.

Bumps the cache type to avoid polluted caches from previous versions.