### PR TITLE
Removes the potential of a None result.

### DIFF
--- a/benchmarks/bench_decode.py
+++ b/benchmarks/bench_decode.py
@@ -32,16 +32,16 @@ for _p in (_REPO_ROOT, _CY_SCALE_PATH):
 # Imports
 # ---------------------------------------------------------------------------
 
-from bt_decode import PortableRegistry
-from bt_decode import decode as bt_decode_one
-from bt_decode import decode_list as bt_decode_many
+from bt_decode import PortableRegistry  # noqa: E402
+from bt_decode import decode as bt_decode_one  # noqa: E402
+from bt_decode import decode_list as bt_decode_many  # noqa: E402
 
-import scalecodec
+import scalecodec  # noqa: E402
 
-from scalecodec.base import RuntimeConfigurationObject
-from scalecodec import ScaleBytes
-from scalecodec.type_registry import load_type_registry_preset
-from scalecodec.utils.ss58 import ss58_encode as _ss58_encode
+from scalecodec.base import RuntimeConfigurationObject  # noqa: E402
+from scalecodec import ScaleBytes  # noqa: E402
+from scalecodec.type_registry import load_type_registry_preset  # noqa: E402
+from scalecodec.utils.ss58 import ss58_encode as _ss58_encode  # noqa: E402
 
 print(f"scalecodec: {scalecodec.__file__}", flush=True)
 
@@ -373,21 +373,21 @@ def bench(fixture_path: str, iters: int):
             _ts_bare_list = [_ts_bare] * _synth_n
 
             _bt_old = run(
-                lambda ts=_ts_wrapped_list,
-                r=registry,
-                bl=_wrapped_bytes: bt_decode_many_with_ss58(ts, r, bl),
+                lambda ts=_ts_wrapped_list, r=registry, bl=_wrapped_bytes: (
+                    bt_decode_many_with_ss58(ts, r, bl)
+                ),
                 iters,
             )
             _bt_new = run(
-                lambda ts=_ts_bare_list,
-                r=registry,
-                bl=_bare_bytes: bt_decode_many_with_ss58(ts, r, bl),
+                lambda ts=_ts_bare_list, r=registry, bl=_bare_bytes: (
+                    bt_decode_many_with_ss58(ts, r, bl)
+                ),
                 iters,
             )
             _cy_old = run(
-                lambda ts=_ts_wrapped_list,
-                r=rc,
-                bl=_wrapped_bytes: cyscale_batch_decode(ts, r, bl),
+                lambda ts=_ts_wrapped_list, r=rc, bl=_wrapped_bytes: (
+                    cyscale_batch_decode(ts, r, bl)
+                ),
                 iters,
             )
             _cy_new = run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,5 +72,5 @@ dev = [
     "bittensor-wallet>=4.0.0",
     "pytest-forked",
     "mypy>=1.20.1",
-    "ruff==0.11.5",
+    "ruff==0.15.12",
 ]

--- a/tests/integration_tests/test_disk_cache.py
+++ b/tests/integration_tests/test_disk_cache.py
@@ -26,7 +26,7 @@ async def test_disk_cache():
     async with DiskCachedAsyncSubstrateInterface(
         LATENT_LITE_ENTRYPOINT, ss58_format=42, chain_name="Bittensor"
     ) as disk_cached_substrate:
-        current_block = await disk_cached_substrate.get_block_number(None)
+        current_block = await disk_cached_substrate.get_block_number(None) - 5
         block_hash = await disk_cached_substrate.get_block_hash(current_block)
         parent_block_hash = await disk_cached_substrate.get_parent_block_hash(
             block_hash


### PR DESCRIPTION
This test frequently fails once per run:
https://github.com/latent-to/async-substrate-interface/actions/runs/25052801085/job/73384804927?pr=334

This should remove that possibility.

(Also bumps ruff)