### PR TITLE
Release/2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.0.3 /2025-04-29
+
+## What's Changed
+
+* use cyscale 0.3.1 by @thewhaleking in https://github.com/latent-to/async-substrate-interface/pull/332
+* Removes the potential of a None result. by @thewhaleking
+  in https://github.com/latent-to/async-substrate-interface/pull/335
+* Updates README regarding cyscale by @thewhaleking in https://github.com/latent-to/async-substrate-interface/pull/334
+* Bumps cyscale + cache version by @thewhaleking in https://github.com/latent-to/async-substrate-interface/pull/338
+
+**Full Changelog**: https://github.com/latent-to/async-substrate-interface/compare/v2.0.1...v2.0.3
+
 ## 2.0.2 /2025-04-24
 
 ## What's Changed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,20 @@
 # Async Substrate Interface
-This project provides an asynchronous interface for interacting with [Substrate](https://substrate.io/)-based blockchains. It is based on the [py-substrate-interface](https://github.com/polkascan/py-substrate-interface) project.
 
-Additionally, this project uses [bt-decode](https://github.com/opentensor/bt-decode) instead of [py-scale-codec](https://github.com/polkascan/py-scale-codec) for faster [SCALE](https://docs.substrate.io/reference/scale-codec/) decoding.
+This project provides an asynchronous interface for interacting with [Substrate](https://substrate.io/)-based
+blockchains. Its API is based on the [py-substrate-interface](https://github.com/polkascan/py-substrate-interface)
+project, but is not fully compatible.
+
+Additionally, this project uses [cyscale](https://github.com/latent-to/cyscale) instead
+of [py-scale-codec](https://github.com/polkascan/py-scale-codec) for
+faster [SCALE](https://docs.substrate.io/reference/scale-codec/) decoding. Since v2.0, because cyscale and
+py-substrate-interface share the same namespace, we require that only
+cyscale is installed to be able to use this. If you run into a runtime error stating that both cannot be installed at
+the same time, simply remove them both, and reinstall cyscale:
+
+```shell
+pip uninstall cyscale scalecodec -y
+pip install cyscale
+```
 
 ## Installation
 
@@ -18,6 +31,7 @@ Here are examples of how to use the sync and async interfaces:
 ```python
 from async_substrate_interface import SubstrateInterface
 
+
 def main():
     substrate = SubstrateInterface(
         url="wss://rpc.polkadot.io"
@@ -31,12 +45,14 @@ def main():
 
         print(result)
 
+
 main()
 ```
 
 ```python
 import asyncio
 from async_substrate_interface import AsyncSubstrateInterface
+
 
 async def main():
     substrate = AsyncSubstrateInterface(
@@ -51,22 +67,24 @@ async def main():
 
         print(result)
 
+
 asyncio.run(main())
 ```
 
 ### Caching
+
 There are a few different cache types used in this library to improve the performance overall. The one with which
 you are probably familiar is the typical `functools.lru_cache` used in `sync_substrate.SubstrateInterface`.
 
-By default, it uses a max cache size of 512 for smaller returns, and 16 for larger ones. These cache sizes are 
+By default, it uses a max cache size of 512 for smaller returns, and 16 for larger ones. These cache sizes are
 user-configurable using the respective env vars, `SUBSTRATE_CACHE_METHOD_SIZE` and `SUBSTRATE_RUNTIME_CACHE_SIZE`.
 
-They are applied only on methods whose results cannot change — such as the block hash for a given block number 
+They are applied only on methods whose results cannot change — such as the block hash for a given block number
 (small, 512 default), or the runtime for a given runtime version (large, 16 default).
 
-Additionally, in `AsyncSubstrateInterface`, because of its asynchronous nature, we developed our own asyncio-friendly 
-LRU caches. The primary one is the `CachedFetcher` which wraps the same methods as `functools.lru_cache` does in 
-`SubstrateInterface`, but the key difference here is that each request is assigned a future that is returned when the 
+Additionally, in `AsyncSubstrateInterface`, because of its asynchronous nature, we developed our own asyncio-friendly
+LRU caches. The primary one is the `CachedFetcher` which wraps the same methods as `functools.lru_cache` does in
+`SubstrateInterface`, but the key difference here is that each request is assigned a future that is returned when the
 initial request completes. So, if you were to do:
 
 ```python
@@ -76,33 +94,44 @@ bh1, bh2 = await asyncio.gather(
     asi.get_block_hash(bn)
 )
 ```
+
 it would actually only make one single network call, and return the result to both requests. Like `SubstrateInterface`,
 it also takes the `SUBSTRATE_CACHE_METHOD_SIZE` and `SUBSTRATE_RUNTIME_CACHE_SIZE` vars to set cache size.
 
-The third and final caching mechanism we use is `async_substrate_interface.async_substrate.DiskCachedAsyncSubstrateInterface`,
-which functions the same as the normal `AsyncSubstrateInterface`, but that also saves this cache to the disk, so the cache
-is preserved between runs. This is product for a fairly nice use-case (such as `btcli`). As you may call different networks
-with entirely different results, this cache is keyed by the uri supplied at instantiation of the `DiskCachedAsyncSubstrateInterface`
-object, so `DiskCachedAsyncSubstrateInterface(network_1)` and `DiskCachedAsyncSubstrateInterface(network_2)` will not share
-the same on-disk cache.
+The third and final caching mechanism we use is
+`async_substrate_interface.async_substrate.DiskCachedAsyncSubstrateInterface`,
+which functions the same as the normal `AsyncSubstrateInterface`, but that also saves this cache to the disk, so the
+cache
+is preserved between runs. This is product for a fairly nice use-case (such as `btcli`). As you may call different
+networks
+with entirely different results, this cache is keyed by the uri supplied at instantiation of the
+`DiskCachedAsyncSubstrateInterface`
+object, so `DiskCachedAsyncSubstrateInterface(network_1)` and `DiskCachedAsyncSubstrateInterface(network_2)` will not
+share the same on-disk cache.
 
 As with the other two caches, this also takes `SUBSTRATE_CACHE_METHOD_SIZE` and `SUBSTRATE_RUNTIME_CACHE_SIZE` env vars.
 
-
 ### ENV VARS
-The following environment variables are used within async-substrate-interface
- - NO_CACHE (default 0): if set to 1, when using the DiskCachedAsyncSubstrateInterface class, no persistent on-disk cache will be stored, instead using only in-memory cache.
- - CACHE_LOCATION (default `~/.cache/async-substrate-interface`): this determines the location for the cache file, if using DiskCachedAsyncSubstrateInterface
- - SUBSTRATE_CACHE_METHOD_SIZE (default 512): the cache size (either in-memory or on-disk) of the smaller return-size methods (see the Caching section for more info)
- - SUBSTRATE_RUNTIME_CACHE_SIZE (default 16): the cache size (either in-memory or on-disk) of the larger return-size methods (see the Caching section for more info)
 
+The following environment variables are used within async-substrate-interface
+
+- NO_CACHE (default 0): if set to 1, when using the DiskCachedAsyncSubstrateInterface class, no persistent on-disk cache
+  will be stored, instead using only in-memory cache.
+- CACHE_LOCATION (default `~/.cache/async-substrate-interface`): this determines the location for the cache file, if
+  using DiskCachedAsyncSubstrateInterface
+- SUBSTRATE_CACHE_METHOD_SIZE (default 512): the cache size (either in-memory or on-disk) of the smaller return-size
+  methods (see the Caching section for more info)
+- SUBSTRATE_RUNTIME_CACHE_SIZE (default 16): the cache size (either in-memory or on-disk) of the larger return-size
+  methods (see the Caching section for more info)
 
 ## Contributing
 
 Contributions are welcome! Please open an issue or submit a pull request to the `staging` branch.
 
 ### Signed Commits
-All commits in pull requests must be signed. We require signed commits to verify the authenticity of contributions and ensure code integrity.
+
+All commits in pull requests must be signed. We require signed commits to verify the authenticity of contributions and
+ensure code integrity.
 
 To sign your commits, you must have GPG signing configured in Git:
 
@@ -116,10 +145,10 @@ Or configure Git to sign all commits automatically:
 git config --global commit.gpgsign true
 ```
 
-For instructions on setting up GPG key signing, see [GitHub's documentation on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
+For instructions on setting up GPG key signing,
+see [GitHub's documentation on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
 
 > **Note:** Pull requests containing unsigned commits will not be merged.
-
 
 ## License
 
@@ -127,4 +156,5 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 
 ## Contact
 
-For any questions or inquiries, please join the Bittensor Development Discord server: [Church of Rao](https://discord.gg/XC7ucQmq2Q).
+For any questions or inquiries, please join the Bittensor Development Discord
+server: [Church of Rao](https://discord.gg/XC7ucQmq2Q).

--- a/async_substrate_interface/utils/cache.py
+++ b/async_substrate_interface/utils/cache.py
@@ -271,9 +271,9 @@ class AsyncSqliteDB:
         block_hash_mapping: OrderedDict[str, int] = OrderedDict()
         version_mapping: OrderedDict[int, dict] = OrderedDict()
         tables: dict[str, OrderedDict] = {
-            "RuntimeCache_blocks_v4": block_mapping,
-            "RuntimeCache_block_hashes_v4": block_hash_mapping,
-            "RuntimeCache_versions_v4": version_mapping,
+            "RuntimeCache_blocks_v5": block_mapping,
+            "RuntimeCache_block_hashes_v5": block_hash_mapping,
+            "RuntimeCache_versions_v5": version_mapping,
         }
         for table in tables.keys():
             async with self._lock:
@@ -314,9 +314,9 @@ class AsyncSqliteDB:
                 self._db = await _async_connect()
 
             tables = {
-                "RuntimeCache_blocks_v4": block_mapping,
-                "RuntimeCache_block_hashes_v4": block_hash_mapping,
-                "RuntimeCache_versions_v4": version_mapping,
+                "RuntimeCache_blocks_v5": block_mapping,
+                "RuntimeCache_block_hashes_v5": block_hash_mapping,
+                "RuntimeCache_versions_v5": version_mapping,
             }
             for table, mapping in tables.items():
                 local_chain = await self._create_if_not_exists(chain, table)

--- a/benchmarks/bench_decode.py
+++ b/benchmarks/bench_decode.py
@@ -32,16 +32,16 @@ for _p in (_REPO_ROOT, _CY_SCALE_PATH):
 # Imports
 # ---------------------------------------------------------------------------
 
-from bt_decode import PortableRegistry
-from bt_decode import decode as bt_decode_one
-from bt_decode import decode_list as bt_decode_many
+from bt_decode import PortableRegistry  # noqa: E402
+from bt_decode import decode as bt_decode_one  # noqa: E402
+from bt_decode import decode_list as bt_decode_many  # noqa: E402
 
-import scalecodec
+import scalecodec  # noqa: E402
 
-from scalecodec.base import RuntimeConfigurationObject
-from scalecodec import ScaleBytes
-from scalecodec.type_registry import load_type_registry_preset
-from scalecodec.utils.ss58 import ss58_encode as _ss58_encode
+from scalecodec.base import RuntimeConfigurationObject  # noqa: E402
+from scalecodec import ScaleBytes  # noqa: E402
+from scalecodec.type_registry import load_type_registry_preset  # noqa: E402
+from scalecodec.utils.ss58 import ss58_encode as _ss58_encode  # noqa: E402
 
 print(f"scalecodec: {scalecodec.__file__}", flush=True)
 
@@ -373,21 +373,21 @@ def bench(fixture_path: str, iters: int):
             _ts_bare_list = [_ts_bare] * _synth_n
 
             _bt_old = run(
-                lambda ts=_ts_wrapped_list,
-                r=registry,
-                bl=_wrapped_bytes: bt_decode_many_with_ss58(ts, r, bl),
+                lambda ts=_ts_wrapped_list, r=registry, bl=_wrapped_bytes: (
+                    bt_decode_many_with_ss58(ts, r, bl)
+                ),
                 iters,
             )
             _bt_new = run(
-                lambda ts=_ts_bare_list,
-                r=registry,
-                bl=_bare_bytes: bt_decode_many_with_ss58(ts, r, bl),
+                lambda ts=_ts_bare_list, r=registry, bl=_bare_bytes: (
+                    bt_decode_many_with_ss58(ts, r, bl)
+                ),
                 iters,
             )
             _cy_old = run(
-                lambda ts=_ts_wrapped_list,
-                r=rc,
-                bl=_wrapped_bytes: cyscale_batch_decode(ts, r, bl),
+                lambda ts=_ts_wrapped_list, r=rc, bl=_wrapped_bytes: (
+                    cyscale_batch_decode(ts, r, bl)
+                ),
                 iters,
             )
             _cy_new = run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "async-substrate-interface"
-version = "2.0.2"
+version = "2.0.3"
 description = "Asyncio library for interacting with substrate. Mostly API-compatible with py-substrate-interface"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,5 +72,5 @@ dev = [
     "bittensor-wallet>=4.0.0",
     "pytest-forked",
     "mypy>=1.20.1",
-    "ruff==0.11.5",
+    "ruff==0.15.12",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ keywords = ["substrate", "development", "bittensor"]
 dependencies = [
     "wheel",
     "aiosqlite>=0.21.0,<1.0.0",
-    "cyscale>=0.3.1,<1.0.0",
+    "cyscale>=0.3.3,<1.0.0",
     "websockets>=14.1",
     "xxhash",
 ]

--- a/tests/integration_tests/test_disk_cache.py
+++ b/tests/integration_tests/test_disk_cache.py
@@ -26,7 +26,7 @@ async def test_disk_cache():
     async with DiskCachedAsyncSubstrateInterface(
         LATENT_LITE_ENTRYPOINT, ss58_format=42, chain_name="Bittensor"
     ) as disk_cached_substrate:
-        current_block = await disk_cached_substrate.get_block_number(None)
+        current_block = await disk_cached_substrate.get_block_number(None) - 5
         block_hash = await disk_cached_substrate.get_block_hash(current_block)
         parent_block_hash = await disk_cached_substrate.get_parent_block_hash(
             block_hash

--- a/tests/unit_tests/test_types.py
+++ b/tests/unit_tests/test_types.py
@@ -76,7 +76,7 @@ async def test_runtime_cache_from_disk():
         # insert some fake data into our DB
         conn = sqlite3.connect(test_db_location)
         conn.execute(
-            "INSERT INTO RuntimeCache_blocks_v4 (key, value, chain) VALUES (?, ?, ?)",
+            "INSERT INTO RuntimeCache_blocks_v5 (key, value, chain) VALUES (?, ?, ?)",
             (fake_block, pickle.dumps(fake_hash), fake_chain),
         )
         conn.commit()
@@ -94,7 +94,7 @@ async def test_runtime_cache_from_disk():
         # verify that our added item is now in the DB
         conn = sqlite3.connect(test_db_location)
         cursor = conn.cursor()
-        cursor.execute("SELECT key, value, chain FROM RuntimeCache_blocks_v4")
+        cursor.execute("SELECT key, value, chain FROM RuntimeCache_blocks_v5")
         query = cursor.fetchall()
         cursor.close()
         conn.close()


### PR DESCRIPTION
## 2.0.3 /2025-04-29

## What's Changed

* use cyscale 0.3.1 by @thewhaleking in https://github.com/latent-to/async-substrate-interface/pull/332
* Removes the potential of a None result. by @thewhaleking
  in https://github.com/latent-to/async-substrate-interface/pull/335
* Updates README regarding cyscale by @thewhaleking in https://github.com/latent-to/async-substrate-interface/pull/334
* Bumps cyscale + cache version by @thewhaleking in https://github.com/latent-to/async-substrate-interface/pull/338

**Full Changelog**: https://github.com/latent-to/async-substrate-interface/compare/v2.0.1...v2.0.3
