### PR TITLE
Bumps wheel for CVE-2026-24049

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = { file = "LICENSE" }
 keywords = ["substrate", "development", "bittensor"]
 
 dependencies = [
-    "wheel",
+    "wheel>0.46.1",
     "aiosqlite>=0.21.0,<1.0.0",
     "cyscale>=0.3.3,<1.0.0",
     "websockets>=14.1",


### PR DESCRIPTION
Was just `wheel` before, so risk was already extremely low. This is just CYA.