### PR TITLE
Fixes return type hint for `get_extrinsics`

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -2291,7 +2291,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
     async def get_extrinsics(
         self, block_hash: Optional[str] = None, block_number: Optional[int] = None
-    ) -> Optional[list["AsyncExtrinsicReceipt"]]:
+    ) -> Optional[list[GenericExtrinsic]]:
         """
         Return all extrinsics for given block_hash or block_number
 

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -1489,7 +1489,7 @@ class SubstrateInterface(SubstrateMixin):
 
     def get_extrinsics(
         self, block_hash: Optional[str] = None, block_number: Optional[int] = None
-    ) -> Optional[list["ExtrinsicReceipt"]]:
+    ) -> Optional[list[GenericExtrinsic]]:
         """
         Return all extrinsics for given block_hash or block_number
 


### PR DESCRIPTION
It's actually never been (Async)ExtrinsicReceipt