### PR TITLE
fix:auto-signed extrinsics to use account_nextIndex

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -3135,7 +3135,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
             keypair: Keypair used to sign the extrinsic
             era: Specify mortality in blocks in follow format:
                 {'period': [amount_blocks]} If omitted the extrinsic is immortal
-            nonce: nonce to include in extrinsics, if omitted the current nonce is retrieved on-chain
+            nonce: nonce to include in extrinsics, if omitted the next account index is retrieved on-chain
             tip: The tip for the block author to gain priority during network congestion
             tip_asset_id: Optional asset ID with which to pay the tip
             signature: Optionally provide signature if externally signed
@@ -3158,7 +3158,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
         # Retrieve nonce
         if nonce is None:
-            nonce = await self.get_account_nonce(keypair.ss58_address) or 0
+            nonce = await self.get_account_next_index(keypair.ss58_address) or 0
 
         # Process era
         if era is None:
@@ -3451,7 +3451,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
         Args:
             account_address: SS58 formatted address
-            use_cache: If True, bypass local nonce cache and always request fresh value from RPC.
+            use_cache: If False, bypass local nonce cache and always request fresh value from RPC.
 
         Returns:
             Next index for the given account address
@@ -3568,7 +3568,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
                      required
             era: Specify mortality in blocks in follow format:
                 {'period': [amount_blocks]} If omitted the extrinsic is immortal
-            nonce: nonce to include in extrinsics, if omitted the current nonce is retrieved on-chain
+            nonce: nonce to include in extrinsics, if omitted the next account index is retrieved on-chain
             tip: The tip for the block author to gain priority during network congestion
             tip_asset_id: Optional asset ID with which to pay the tip
 
@@ -3945,7 +3945,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
             max_weight: Maximum allowed weight to execute the call ( Uses `get_payment_info()` by default)
             era: Specify mortality in blocks in follow format: {'period': [amount_blocks]} If omitted the extrinsic is
                 immortal
-            nonce: nonce to include in extrinsics, if omitted the current nonce is retrieved on-chain
+            nonce: nonce to include in extrinsics, if omitted the next account index is retrieved on-chain
             tip: The tip for the block author to gain priority during network congestion
             tip_asset_id: Optional asset ID with which to pay the tip
             signature: Optionally provide signature if externally signed

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -2247,7 +2247,7 @@ class SubstrateInterface(SubstrateMixin):
             keypair: Keypair used to sign the extrinsic
             era: Specify mortality in blocks in follow format:
                 {'period': [amount_blocks]} If omitted the extrinsic is immortal
-            nonce: nonce to include in extrinsics, if omitted the current nonce is retrieved on-chain
+            nonce: nonce to include in extrinsics, if omitted the next account index is retrieved on-chain
             tip: The tip for the block author to gain priority during network congestion
             tip_asset_id: Optional asset ID with which to pay the tip
             signature: Optionally provide signature if externally signed
@@ -2271,7 +2271,7 @@ class SubstrateInterface(SubstrateMixin):
 
         # Retrieve nonce
         if nonce is None:
-            nonce = self.get_account_nonce(keypair.ss58_address) or 0
+            nonce = self.get_account_next_index(keypair.ss58_address) or 0
 
         # Process era
         if era is None:
@@ -2613,7 +2613,7 @@ class SubstrateInterface(SubstrateMixin):
                      required
             era: Specify mortality in blocks in follow format:
                 {'period': [amount_blocks]} If omitted the extrinsic is immortal
-            nonce: nonce to include in extrinsics, if omitted the current nonce is retrieved on-chain
+            nonce: nonce to include in extrinsics, if omitted the next account index is retrieved on-chain
             tip: The tip for the block author to gain priority during network congestion
             tip_asset_id: Optional asset ID with which to pay the tip
 
@@ -2926,7 +2926,7 @@ class SubstrateInterface(SubstrateMixin):
             max_weight: Maximum allowed weight to execute the call ( Uses `get_payment_info()` by default)
             era: Specify mortality in blocks in follow format: {'period': [amount_blocks]} If omitted the extrinsic is
                 immortal
-            nonce: nonce to include in extrinsics, if omitted the current nonce is retrieved on-chain
+            nonce: nonce to include in extrinsics, if omitted the next account index is retrieved on-chain
             tip: The tip for the block author to gain priority during network congestion
             tip_asset_id: Optional asset ID with which to pay the tip
             signature: Optionally provide signature if externally signed

--- a/tests/e2e_tests/test_e2e_async.py
+++ b/tests/e2e_tests/test_e2e_async.py
@@ -2,6 +2,7 @@ import asyncio
 import time
 import tracemalloc
 
+from bittensor_wallet.keypair import Keypair
 import pytest_asyncio
 import pytest
 from websockets.protocol import State
@@ -794,3 +795,45 @@ async def test_memory_leak():
             f"Loop {i}: diff={total_diff / 1024:.2f} KiB, current={current / 1024:.2f} KiB, "
             f"peak={peak / 1024:.2f} KiB"
         )
+
+
+@pytest.mark.asyncio
+async def test_get_payment_info(substrate):
+    """
+    This exists in e2e and not in integration like its sync version due to the discrepancy
+    between the get_next_account_index cache in the two.
+    """
+    print("Testing test_get_payment_info")
+    alice_coldkey = Keypair.create_from_uri("//Alice")
+    bob_coldkey = Keypair.create_from_uri("//Bob")
+    block_hash = await substrate.get_chain_head()
+    call = await substrate.compose_call(
+        "Balances",
+        "transfer_keep_alive",
+        {"dest": bob_coldkey.ss58_address, "value": 100_000},
+        block_hash,
+    )
+    payment_info = await substrate.get_payment_info(
+        call=call,
+        keypair=alice_coldkey,
+    )
+    partial_fee_no_era = payment_info["partial_fee"]
+    assert partial_fee_no_era > 0
+    payment_info_era = await substrate.get_payment_info(
+        call=call, keypair=alice_coldkey, era={"period": 64}
+    )
+    partial_fee_era = payment_info_era["partial_fee"]
+    assert partial_fee_era > partial_fee_no_era
+
+    payment_info_all_options = await substrate.get_payment_info(
+        call=call,
+        keypair=alice_coldkey,
+        era={"period": 64},
+        nonce=await substrate.get_account_next_index(alice_coldkey.ss58_address),
+        tip=5_000_000,
+        tip_asset_id=64,
+    )
+    partial_fee_all_options = payment_info_all_options["partial_fee"]
+    assert partial_fee_all_options > partial_fee_no_era
+    assert partial_fee_all_options > partial_fee_era
+    print("test_get_payment_info succeeded")

--- a/tests/helpers/integration_websocket_data.py
+++ b/tests/helpers/integration_websocket_data.py
@@ -1292,78 +1292,93 @@ WEBSOCKET_RESPONSES = {
     "test_get_payment_info": {
         "chain_getHead": {
             "[]": {
-                "result": "0x837f6882f1868913bff6868929f33a1b20bbdcb94c4f5ded40624af353af2f2b"
+                "result": "0xeb7c1f8c49a28cb0073fa0daa65e9d69e8db7ac5d511f3b93e817808fcd76bce"
             }
         },
         "chain_getHeader": {
-            '["0xd5d35dc399ee8bba2842f896209d27b605a35d9135b1fdeb1404e3b9af82acaf"]': {
+            '["0x43002a8cea77be5ba8dbddd80ea32e34a4b8eae675a7b776f22db8f92dd7bdf8"]': {
                 "result": {
-                    "parentHash": "0xc01b849c25ea8bbc4c79e4b562ec12e5b084ecf1152adf4589a5fa84b75f6b48",
-                    "number": "0x79737f",
-                    "stateRoot": "0xdc3cc927222da209cca3528260c5cb0564ab139d7d975914df683be149658eb5",
-                    "extrinsicsRoot": "0x1b8a1465c7473146410958e7aa3e65ae632f8484b71a4c200ee2d6674e0c2780",
+                    "parentHash": "0x3300f2ecfadff8f9dc79bf9c8f1382c0d82fa302ffde8b36383dcf2301b0b5eb",
+                    "number": "0x7cc27c",
+                    "stateRoot": "0x0580201b7b25ffa80866941062e65c20709ddadf30707ee32d9d0b3b68d0dc3e",
+                    "extrinsicsRoot": "0x6d2e5649c69d9db379cf3c3afd4c0b5a1f0cdbfaa413f1df7079692c84a8eff5",
                     "digest": {
                         "logs": [
-                            "0x0661757261207e68d20800000000",
-                            "0x0466726f6e890201846740d9540c233d813031b1c10d30a27df609bc66dd2c51b05862997cf0d9c910bfd1ec64c06dea0faecfa267e3b896e64d22727b5fc34f4d6c094929cfee99d4c5db462e339fd7f87e49f339d3efabc74466ecae180db9cace4c00c3c54a0279448af30312a88b17edddb3de98cd4f01e3fe3a3c10a8d3a828048c5231aceada09ed8e2f0713912fbfb3ca9670d48119c1b78b9153944b67699bd3e25ca22727",
-                            "0x05617572610101da24ddb587c75bbee600ab52ff1a536a05b2f08d1562d6abc87a8f0657a8f42425c892427a42151202c956032b9c6650b51e4ebabadbe411c63c6c87cec9a78e",
+                            "0x066175726120b4b9d50800000000",
+                            "0x0466726f6e8903011201f8845fabcf2f0812bddc3a040d232b45fcb0b7b658b912a958d4f742c94318c950046b82842235df90f58e205de488354de9402e7d03b8744b9a32510f0122ea2462dd6f1c362c04aef442ed280477208a82980b5e25bb0c6fdcb98760b80869966be8fc3d1cfd6a4c9e5d3dc2fbb83d4d10ed2351371a792f6cf211fedc7811b0fcebf19e28f0c7444ab5421b2a93b6083a57300a1f847b540f4e453c6aa7e5bc5e8e4b22ab761d9038a6ff05ea79c13a33fed95cd4121ed49cf21d3070956a959ea7ec8cf1588ad30e7857fdff0f5221d54f59b9bc68fac94b9bcec7b9f9",
+                            "0x056175726101013c57c5662b842144bece2a5b18f5decaaae85c6cc09412c7869d8c469dcb37604c90982525e2ea4bf36b8752db5a2f84af5b934ca454d165da87934cb3f9678e",
+                        ]
+                    },
+                }
+            },
+            '["0xb716ff829f1860fa85d159bcb3c939e9bcc4250c7d69fa4871dd0c7f39acfaff"]': {
+                "result": {
+                    "parentHash": "0x43002a8cea77be5ba8dbddd80ea32e34a4b8eae675a7b776f22db8f92dd7bdf8",
+                    "number": "0x7cc27d",
+                    "stateRoot": "0xd72527f39c7592ed5660605b2e1725e83ce5c4670ea64656faa099aa59f06459",
+                    "extrinsicsRoot": "0x6f605502e4ff7bf516608c391f35c61f1368f474a9f51e8b4a83ca75e1f732ae",
+                    "digest": {
+                        "logs": [
+                            "0x066175726120b5b9d50800000000",
+                            "0x0466726f6e890301a1b93d6075498ce9e419ecb27df0bc38f9fd9b4568a6f817973534610d0318fe1816cf49cf38803976fc016c2d938e89d6f4460781f16af30be037ccaf6120031f1360177f6277d727296d7ea7ab0ee8c93a05f5f7c23712ba642514cffe18d1cb33a7600a2707807bcea943c56e8d2d39db6f78586f309c299a5979e9b48665707c37338add1e8959b0c560056dcaf98d9518371514702c597cc28b77f86ca40d187bf56819db03d6f5ef08f460abe6c477d1f3bd89964ad880636b7590c909c4abb9e998512ebc45da8a0e732b115a9dcdbf2743439a0193e475d1aa95b1476b",
+                            "0x05617572610101643c0af6f2d7031b5d531145db5757262f48140c75b5e36e35837f3097c1f8219a8669a7d47287417f675c919c7f1eb674c546f1725afcb06e3514d8c6a5fa85",
                         ]
                     },
                 }
             },
             "[null]": {
                 "result": {
-                    "parentHash": "0xd5d35dc399ee8bba2842f896209d27b605a35d9135b1fdeb1404e3b9af82acaf",
-                    "number": "0x797380",
-                    "stateRoot": "0xced9d8b54192f274b2c9e8e0bea31872ddc8712e00e1f0ba439d1bccb1544a8c",
-                    "extrinsicsRoot": "0x93e2e8ae111850f77339d8f0184b1755963d41ecc02ce585b874eb989ff7ac94",
+                    "parentHash": "0x43002a8cea77be5ba8dbddd80ea32e34a4b8eae675a7b776f22db8f92dd7bdf8",
+                    "number": "0x7cc27d",
+                    "stateRoot": "0xd72527f39c7592ed5660605b2e1725e83ce5c4670ea64656faa099aa59f06459",
+                    "extrinsicsRoot": "0x6f605502e4ff7bf516608c391f35c61f1368f474a9f51e8b4a83ca75e1f732ae",
                     "digest": {
                         "logs": [
-                            "0x0661757261207f68d20800000000",
-                            "0x0466726f6e090301a5bc97bb50362aac19752831ec03ab9c52a5845799bdc5c4160385f4a3657f1c14bbcfeb109bbf8d71166d4dd6db3d7a8d114d99eb30da645e672f2456b8403181163fbcfa68d6847e4ebd956147db9caace2a9b36777c28f57f16d8de029316dbab88c28a1ee2afc740b502c7e4845a2d8c53ae3fef513d2b022fc6e49f06bab8bdd6071e16398627d368df1da04332159035b577817985b7b931d51a3049aff58e5192250266db5023b727bdc2b5f71a0f21823b9507daf7c4f0142d1fb908a6",
-                            "0x056175726101017299ffd9877d0beeef0dea67303099c4516523d4bddba88617ba56ae6aac07000279041c982ab0f37b97c567d37894fc75812bce77a4acf06339c6fa1b0c8388",
+                            "0x066175726120b5b9d50800000000",
+                            "0x0466726f6e890301a1b93d6075498ce9e419ecb27df0bc38f9fd9b4568a6f817973534610d0318fe1816cf49cf38803976fc016c2d938e89d6f4460781f16af30be037ccaf6120031f1360177f6277d727296d7ea7ab0ee8c93a05f5f7c23712ba642514cffe18d1cb33a7600a2707807bcea943c56e8d2d39db6f78586f309c299a5979e9b48665707c37338add1e8959b0c560056dcaf98d9518371514702c597cc28b77f86ca40d187bf56819db03d6f5ef08f460abe6c477d1f3bd89964ad880636b7590c909c4abb9e998512ebc45da8a0e732b115a9dcdbf2743439a0193e475d1aa95b1476b",
+                            "0x05617572610101643c0af6f2d7031b5d531145db5757262f48140c75b5e36e35837f3097c1f8219a8669a7d47287417f675c919c7f1eb674c546f1725afcb06e3514d8c6a5fa85",
                         ]
                     },
                 }
             },
-            '["0x837f6882f1868913bff6868929f33a1b20bbdcb94c4f5ded40624af353af2f2b"]': {
+            '["0x3300f2ecfadff8f9dc79bf9c8f1382c0d82fa302ffde8b36383dcf2301b0b5eb"]': {
                 "result": {
-                    "parentHash": "0xd5d35dc399ee8bba2842f896209d27b605a35d9135b1fdeb1404e3b9af82acaf",
-                    "number": "0x797380",
-                    "stateRoot": "0xced9d8b54192f274b2c9e8e0bea31872ddc8712e00e1f0ba439d1bccb1544a8c",
-                    "extrinsicsRoot": "0x93e2e8ae111850f77339d8f0184b1755963d41ecc02ce585b874eb989ff7ac94",
+                    "parentHash": "0xfef20fd648e09905388dc1018a456c5e689b04560da7ae42c7ec7a3c33c1fec0",
+                    "number": "0x7cc27b",
+                    "stateRoot": "0x4f3f09a548bb0b1519045b533054b488d08247b73f0023e16746b5e142efbed8",
+                    "extrinsicsRoot": "0x756e22d31acb0942c0fc0b5c10f617cdd4eec4175929ca6c18fd7db236337ab0",
                     "digest": {
                         "logs": [
-                            "0x0661757261207f68d20800000000",
-                            "0x0466726f6e090301a5bc97bb50362aac19752831ec03ab9c52a5845799bdc5c4160385f4a3657f1c14bbcfeb109bbf8d71166d4dd6db3d7a8d114d99eb30da645e672f2456b8403181163fbcfa68d6847e4ebd956147db9caace2a9b36777c28f57f16d8de029316dbab88c28a1ee2afc740b502c7e4845a2d8c53ae3fef513d2b022fc6e49f06bab8bdd6071e16398627d368df1da04332159035b577817985b7b931d51a3049aff58e5192250266db5023b727bdc2b5f71a0f21823b9507daf7c4f0142d1fb908a6",
-                            "0x056175726101017299ffd9877d0beeef0dea67303099c4516523d4bddba88617ba56ae6aac07000279041c982ab0f37b97c567d37894fc75812bce77a4acf06339c6fa1b0c8388",
+                            "0x066175726120b3b9d50800000000",
+                            "0x0466726f6e0903015b813b06c32a7060fde458d8e48f084c689b864d0b276f80708fc13c11535f2c14787e1b000fd89cb162dbcd73dfa06ce74dce73dd4d0e47fdd6035c0c8b619137e7e52aca89c231ddf7122d31de7cb3eb57e434aad8e91894997b0ba6d43c0f0b4bbce39a7608a3b2c34213ae872b099ad3706894f48081343e20a3ad9cda3a29cd05d35c8c65af07ec2f6db4557d407566eff4c7c8252ec2162abc3b5b36bdfc54b47f92dfe7bf1f2f5f253c22aa58e4d83341e8128735abb9751e60dde4d84d",
+                            "0x05617572610101f8aa089cd9a5edf7a2cb74ee0ee8a3d4aa634da9492e5ab4fd77da8156e1ce2766e4083884ee971dc0e10686740c7a1688bc4076fdbd2ca2bb0f6f5327f05c80",
                         ]
                     },
                 }
             },
-            '["0xc01b849c25ea8bbc4c79e4b562ec12e5b084ecf1152adf4589a5fa84b75f6b48"]': {
+            '["0xeb7c1f8c49a28cb0073fa0daa65e9d69e8db7ac5d511f3b93e817808fcd76bce"]': {
                 "result": {
-                    "parentHash": "0x2b8ebc650629b6c2163c537c4870c47f3710fedebe68e7251fd752a4b186dc51",
-                    "number": "0x79737e",
-                    "stateRoot": "0x7547cde778d593cc3dbb222c08d3edb5b5ddddfe183637e9d4691cf7d029e4c8",
-                    "extrinsicsRoot": "0xd4a97fb7a916d9d8adab88beaaaa9721b7a80cc4496f677458566df29a10574a",
+                    "parentHash": "0xb716ff829f1860fa85d159bcb3c939e9bcc4250c7d69fa4871dd0c7f39acfaff",
+                    "number": "0x7cc27e",
+                    "stateRoot": "0x220aaab82e28d2c5acd1b15fe798fe3e06170ab05c2e7487f8211547e00bd537",
+                    "extrinsicsRoot": "0xa61bf2b28fc24ad7b6a1bd3d821f8129ca361f56e541f1256a91f4d6e1714d8b",
                     "digest": {
                         "logs": [
-                            "0x0661757261207d68d20800000000",
-                            "0x0466726f6e09030113fbec9c7186f720affbcdaf565f12fdc155f5cb463eade6faa0df6e1c382a7d14bdce57c2b5e561d0c53e42ed5375cb8ad54f811f80aa66ccca5c009dfbbaf84cefdcc32ffa072645e19fc347f5ad0ae6a5017945554aab1b1a916bc97939d7e11634947b478ee4a6d106e0370d04695d90a6c35b9b0670cf85dbb6b967348f71ace86d686fe1b6182d195f5bb9200e13384952ef2b3ea907527ef801794b8ae1f1232493ed043ae02fd442bb14f4e2682b8509ee3a6266f29cc724c24fbe5292",
-                            "0x05617572610101905c48d13e9646d2c96bfed32e36b7ce5d2a35986c2f9df282902cdc9072062384799ba5703b6d666be826b4af1a949a52a17f773d102f9161d3a2c389716b83",
+                            "0x066175726120b6b9d50800000000",
+                            "0x0466726f6e890301b5573810951df02a6fe75dde247c48ff45b67a5876b6459c71307022925cb8d018be0a3cfe0fc231580f41ee5596fdc8fec06a92b42e99a160d46223689b52df5ad3efde6274c8870ea7fb89f9416467fef4cf9f24265e3a4765572f91f71c0f6621c139a163122a0586231b21710a8af420cbed8d8c37d7ae0177edde45104e81a3d097feb7c03037e9c69b16ed277a6552bbfb306a610740c30ad62b4393c28eae033b1ac62d398eb8a3ce515f22633ae58115c7ffd3dc403ec6d61f4d929cb7f68a3c16a0ff8f69bf72a0bf506b353956778b4d7ff8c01c0e3d874054e4a307",
+                            "0x05617572610101427f1638d69ac6dd04aeb213c3804315e9363c40991831dde2301c70aa28ba58ab2120acaa9a7c41b9393982ab9e55ecbcea4c42e36c4afb4aad57f7154a3680",
                         ]
                     },
                 }
             },
         },
         "state_getRuntimeVersion": {
-            '["0xc01b849c25ea8bbc4c79e4b562ec12e5b084ecf1152adf4589a5fa84b75f6b48"]': {
+            '["0x3300f2ecfadff8f9dc79bf9c8f1382c0d82fa302ffde8b36383dcf2301b0b5eb"]': {
                 "result": {
                     "specName": "node-subtensor",
                     "implName": "node-subtensor",
                     "authoringVersion": 1,
-                    "specVersion": 393,
+                    "specVersion": 402,
                     "implVersion": 1,
                     "apis": [
                         ["0xdf6acb689907609b", 5],
@@ -1395,12 +1410,49 @@ WEBSOCKET_RESPONSES = {
                     "stateVersion": 1,
                 }
             },
-            '["0xd5d35dc399ee8bba2842f896209d27b605a35d9135b1fdeb1404e3b9af82acaf"]': {
+            '["0x43002a8cea77be5ba8dbddd80ea32e34a4b8eae675a7b776f22db8f92dd7bdf8"]': {
                 "result": {
                     "specName": "node-subtensor",
                     "implName": "node-subtensor",
                     "authoringVersion": 1,
-                    "specVersion": 393,
+                    "specVersion": 402,
+                    "implVersion": 1,
+                    "apis": [
+                        ["0xdf6acb689907609b", 5],
+                        ["0x37e397fc7c91f5e4", 2],
+                        ["0x40fe3ad401f8959a", 6],
+                        ["0xfbc577b9d747efd6", 1],
+                        ["0xd2bc9897eed08f15", 3],
+                        ["0xf78b278be53f454c", 2],
+                        ["0xdd718d5cc53262d4", 1],
+                        ["0xab3c0572291feb8b", 1],
+                        ["0xed99c5acb25eedf5", 3],
+                        ["0xbc9d89904f5b923f", 1],
+                        ["0x37c8bb1350a9a2a8", 4],
+                        ["0xf3ff14d5ab527059", 3],
+                        ["0x582211f65bb14b89", 6],
+                        ["0xe65b00e46cedd0aa", 2],
+                        ["0x68b66ba122c93fa7", 2],
+                        ["0x42e62be4a39e5b60", 1],
+                        ["0x806df4ccaa9ed485", 1],
+                        ["0x8375104b299b74c5", 1],
+                        ["0x5d1fbfbe852f2807", 1],
+                        ["0xc6886e2f8e598b0a", 1],
+                        ["0xcbca25e39f142387", 2],
+                        ["0xa8b093e6508d9e9c", 1],
+                        ["0x1c4585bd5c707202", 1],
+                    ],
+                    "transactionVersion": 1,
+                    "systemVersion": 1,
+                    "stateVersion": 1,
+                }
+            },
+            '["0xb716ff829f1860fa85d159bcb3c939e9bcc4250c7d69fa4871dd0c7f39acfaff"]': {
+                "result": {
+                    "specName": "node-subtensor",
+                    "implName": "node-subtensor",
+                    "authoringVersion": 1,
+                    "specVersion": 402,
                     "implVersion": 1,
                     "apis": [
                         ["0xdf6acb689907609b", 5],
@@ -1434,12 +1486,9 @@ WEBSOCKET_RESPONSES = {
             },
         },
         "chain_getBlockHash": {
-            "[7959423]": {
-                "result": "0xd5d35dc399ee8bba2842f896209d27b605a35d9135b1fdeb1404e3b9af82acaf"
-            },
-            "[7959424]": {
-                "result": "0x837f6882f1868913bff6868929f33a1b20bbdcb94c4f5ded40624af353af2f2b"
-            },
+            "[8176253]": {
+                "result": "0xb716ff829f1860fa85d159bcb3c939e9bcc4250c7d69fa4871dd0c7f39acfaff"
+            }
         },
         "rpc_methods": {
             "[]": {
@@ -1645,23 +1694,26 @@ WEBSOCKET_RESPONSES = {
                 }
             }
         },
+        "account_nextIndex": {
+            '["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"]': {"result": 0}
+        },
         "state_call": {
+            '["TransactionPaymentApi_query_info", "39028400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d0100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000503008eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48821a060090000000", null]': {
+                "result": "0xe2a20833253800df75020000000000"
+            },
+            '["TransactionPaymentApi_query_info", "3d028400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d0100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000b5030000000503008eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48821a060091000000", null]': {
+                "result": "0xe2a20833253800e075020000000000"
+            },
             '["AccountNonceApi_account_nonce", "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d", null]': {
                 "result": "0x00000000"
             },
-            '["TransactionPaymentApi_query_info", "39028400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d0100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000503008eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48821a060090000000", null]': {
-                "result": "0xe2e01c272538003714020000000000"
-            },
-            '["TransactionPaymentApi_query_info", "3d028400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d0100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e5030000000503008eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48821a060091000000", null]': {
-                "result": "0xe2e01c272538003814020000000000"
-            },
-            '["TransactionPaymentApi_query_info", "49028400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d0100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e50300022d3101000503008eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48821a060094000000", null]': {
-                "result": "0xe2e01c272538003b14020000000000"
+            '["TransactionPaymentApi_query_info", "49028400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d0100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000b50300022d3101000503008eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48821a060094000000", null]': {
+                "result": "0xe2a20833253800e375020000000000"
             },
         },
         "chain_getFinalizedHead": {
             "[]": {
-                "result": "0xc01b849c25ea8bbc4c79e4b562ec12e5b084ecf1152adf4589a5fa84b75f6b48"
+                "result": "0x3300f2ecfadff8f9dc79bf9c8f1382c0d82fa302ffde8b36383dcf2301b0b5eb"
             }
         },
     },

--- a/tests/integration_tests/test_async_substrate_interface_integration.py
+++ b/tests/integration_tests/test_async_substrate_interface_integration.py
@@ -156,43 +156,6 @@ async def test_improved_reconnection():
     print("test_improved_reconnection succeeded")
 
 
-@pytest.mark.asyncio
-async def test_get_payment_info(alice_coldkey, bob_coldkey):
-    print("Testing test_get_payment_info")
-    substrate = await get_mock_substrate("test_get_payment_info")
-    block_hash = await substrate.get_chain_head()
-    call = await substrate.compose_call(
-        "Balances",
-        "transfer_keep_alive",
-        {"dest": bob_coldkey.ss58_address, "value": 100_000},
-        block_hash,
-    )
-    payment_info = await substrate.get_payment_info(
-        call=call,
-        keypair=alice_coldkey,
-    )
-    partial_fee_no_era = payment_info["partial_fee"]
-    assert partial_fee_no_era > 0
-    payment_info_era = await substrate.get_payment_info(
-        call=call, keypair=alice_coldkey, era={"period": 64}
-    )
-    partial_fee_era = payment_info_era["partial_fee"]
-    assert partial_fee_era > partial_fee_no_era
-
-    payment_info_all_options = await substrate.get_payment_info(
-        call=call,
-        keypair=alice_coldkey,
-        era={"period": 64},
-        nonce=await substrate.get_account_nonce(alice_coldkey.ss58_address),
-        tip=5_000_000,
-        tip_asset_id=64,
-    )
-    partial_fee_all_options = payment_info_all_options["partial_fee"]
-    assert partial_fee_all_options > partial_fee_no_era
-    assert partial_fee_all_options > partial_fee_era
-    print("test_get_payment_info succeeded")
-
-
 async def test_bits():
     substrate = await get_mock_substrate("test_bits")
     current_sqrt_price = await substrate.query(

--- a/tests/integration_tests/test_substrate_interface_integration.py
+++ b/tests/integration_tests/test_substrate_interface_integration.py
@@ -74,11 +74,9 @@ def test_query_map_with_odd_number_of_params():
     print("test_query_map_with_odd_number_of_params succeeded")
 
 
-def test_get_payment_info():
+def test_get_payment_info(bob_coldkey, alice_coldkey):
     print("Testing test_get_payment_info")
     substrate = get_mock_substrate("test_get_payment_info")
-    alice_coldkey = bittensor_wallet.Keypair.create_from_uri("//Alice")
-    bob_coldkey = bittensor_wallet.Keypair.create_from_uri("//Bob")
     block_hash = substrate.get_chain_head()
     call = substrate.compose_call(
         "Balances",

--- a/tests/unit_tests/asyncio_/test_substrate_interface_async_unit.py
+++ b/tests/unit_tests/asyncio_/test_substrate_interface_async_unit.py
@@ -9,6 +9,7 @@ from async_substrate_interface.async_substrate import (
     AsyncSubstrateInterface,
 )
 from async_substrate_interface.errors import SubstrateRequestException
+from scalecodec.types import GenericCall
 
 
 @pytest.mark.asyncio
@@ -304,6 +305,74 @@ async def test_get_account_next_index_bypass_mode_raises_on_rpc_error():
             "5F3sa2TJAWMqDhXG6jhV4N8ko9NoFz5Y2s8vS8uM9f7v7mA",
             use_cache=False,
         )
+
+
+def _make_mock_call():
+    call = object.__new__(GenericCall)
+    call.value = {
+        "call_function": "transfer_allow_death",
+        "call_module": "Balances",
+        "call_args": [],
+    }
+    return call
+
+
+def _make_mock_runtime_and_extrinsic():
+    extrinsic = MagicMock()
+    runtime = MagicMock()
+    runtime.metadata = {1: {1: {"extrinsic": {"version": 4}}}}
+    runtime.runtime_config.create_scale_object.return_value = extrinsic
+    runtime.runtime_config.get_decoder_class.return_value = None
+    return runtime, extrinsic
+
+
+@pytest.mark.asyncio
+async def test_create_signed_extrinsic_uses_next_index_when_nonce_omitted():
+    substrate = AsyncSubstrateInterface("ws://localhost", _mock=True)
+    runtime, extrinsic = _make_mock_runtime_and_extrinsic()
+    substrate.init_runtime = AsyncMock(return_value=runtime)
+    substrate.get_account_next_index = AsyncMock(return_value=7)
+    substrate.get_account_nonce = AsyncMock(return_value=3)
+    keypair = MagicMock(
+        ss58_address="5F3sa2TJAWMqDhXG6jhV4N8ko9NoFz5Y2s8vS8uM9f7v7mA",
+        public_key=b"\x01" * 32,
+        crypto_type=1,
+    )
+
+    result = await substrate.create_signed_extrinsic(
+        call=_make_mock_call(),
+        keypair=keypair,
+        signature=b"\x00" * 64,
+    )
+
+    assert result is extrinsic
+    substrate.get_account_next_index.assert_awaited_once_with(keypair.ss58_address)
+    substrate.get_account_nonce.assert_not_awaited()
+    extrinsic.encode.assert_called_once()
+    assert extrinsic.encode.call_args.args[0]["nonce"] == 7
+
+
+@pytest.mark.asyncio
+async def test_create_signed_extrinsic_keeps_explicit_nonce():
+    substrate = AsyncSubstrateInterface("ws://localhost", _mock=True)
+    runtime, extrinsic = _make_mock_runtime_and_extrinsic()
+    substrate.init_runtime = AsyncMock(return_value=runtime)
+    substrate.get_account_next_index = AsyncMock(return_value=7)
+    keypair = MagicMock(
+        ss58_address="5F3sa2TJAWMqDhXG6jhV4N8ko9NoFz5Y2s8vS8uM9f7v7mA",
+        public_key=b"\x01" * 32,
+        crypto_type=1,
+    )
+
+    await substrate.create_signed_extrinsic(
+        call=_make_mock_call(),
+        keypair=keypair,
+        nonce=11,
+        signature=b"\x00" * 64,
+    )
+
+    substrate.get_account_next_index.assert_not_awaited()
+    assert extrinsic.encode.call_args.args[0]["nonce"] == 11
 
 
 class TestAsyncExtrinsicReceiptProcessEvents:

--- a/tests/unit_tests/sync/test_substrate_interface_sync_unit.py
+++ b/tests/unit_tests/sync/test_substrate_interface_sync_unit.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+from scalecodec.types import GenericCall
+
 from async_substrate_interface.sync_substrate import (
     SubstrateInterface,
     QueryMapResult,
@@ -222,6 +224,78 @@ class TestGetBlockNumber:
         substrate.runtime_cache.add_item.assert_called_once_with(
             block_hash="0xABC", block=100
         )
+
+
+def _make_mock_call():
+    call = object.__new__(GenericCall)
+    call.value = {
+        "call_function": "transfer_allow_death",
+        "call_module": "Balances",
+        "call_args": [],
+    }
+    return call
+
+
+def _make_mock_runtime_and_extrinsic():
+    extrinsic = MagicMock()
+    runtime = MagicMock()
+    runtime.metadata = {1: {1: {"extrinsic": {"version": 4}}}}
+    runtime.runtime_config.create_scale_object.return_value = extrinsic
+    runtime.runtime_config.get_decoder_class.return_value = None
+    return runtime, extrinsic
+
+
+def test_create_signed_extrinsic_uses_next_index_when_nonce_omitted():
+    substrate = SubstrateInterface("ws://localhost", _mock=True)
+    runtime, extrinsic = _make_mock_runtime_and_extrinsic()
+    substrate.runtime = runtime
+    substrate.runtime_config = runtime.runtime_config
+    substrate.init_runtime = MagicMock(return_value=runtime)
+    substrate.get_block_number = MagicMock(return_value=1)
+    substrate.get_account_next_index = MagicMock(return_value=7)
+    substrate.get_account_nonce = MagicMock(return_value=3)
+    keypair = MagicMock(
+        ss58_address="5F3sa2TJAWMqDhXG6jhV4N8ko9NoFz5Y2s8vS8uM9f7v7mA",
+        public_key=b"\x01" * 32,
+        crypto_type=1,
+    )
+
+    result = substrate.create_signed_extrinsic(
+        call=_make_mock_call(),
+        keypair=keypair,
+        signature=b"\x00" * 64,
+    )
+
+    assert result is extrinsic
+    substrate.get_account_next_index.assert_called_once_with(keypair.ss58_address)
+    substrate.get_account_nonce.assert_not_called()
+    extrinsic.encode.assert_called_once()
+    assert extrinsic.encode.call_args.args[0]["nonce"] == 7
+
+
+def test_create_signed_extrinsic_keeps_explicit_nonce():
+    substrate = SubstrateInterface("ws://localhost", _mock=True)
+    runtime, extrinsic = _make_mock_runtime_and_extrinsic()
+    substrate.runtime = runtime
+    substrate.runtime_config = runtime.runtime_config
+    substrate.init_runtime = MagicMock(return_value=runtime)
+    substrate.get_block_number = MagicMock(return_value=1)
+    substrate.get_account_next_index = MagicMock(return_value=7)
+    keypair = MagicMock(
+        ss58_address="5F3sa2TJAWMqDhXG6jhV4N8ko9NoFz5Y2s8vS8uM9f7v7mA",
+        public_key=b"\x01" * 32,
+        crypto_type=1,
+    )
+
+    substrate.create_signed_extrinsic(
+        call=_make_mock_call(),
+        keypair=keypair,
+        nonce=11,
+        signature=b"\x00" * 64,
+    )
+
+    substrate.get_account_next_index.assert_not_called()
+    assert extrinsic.encode.call_args.args[0]["nonce"] == 11
 
 
 class TestExtrinsicReceiptProcessEvents:


### PR DESCRIPTION
## Summary

`create_signed_extrinsic` used `get_account_nonce()` when `nonce` was omitted, so the auto-filled nonce came from chain state only. That ignores pending transactions already in the pool for the same account.

This PR switches the omitted-`nonce` path to `get_account_next_index()` for both async and sync interfaces, so auto-signed extrinsics use the pending-aware `account_nextIndex` value by default.

Explicit `nonce=` values are preserved unchanged.

## Related

Fixes https://github.com/latent-to/async-substrate-interface/issues/344

## Affected call sites

- **`AsyncSubstrateInterface.create_signed_extrinsic`** (`async_substrate.py`) — now uses `get_account_next_index()` when `nonce is None`.
- **`SubstrateInterface.create_signed_extrinsic`** (`sync_substrate.py`) — now uses `get_account_next_index()` when `nonce is None`.

## Changes

### `async_substrate_interface/async_substrate.py`

- Replace omitted nonce lookup from `get_account_nonce()` to `get_account_next_index()`.
- Update nonce docstrings to describe the new default behavior.

### `async_substrate_interface/sync_substrate.py`

- Replace omitted nonce lookup from `get_account_nonce()` to `get_account_next_index()`.
- Update nonce docstrings to describe the new default behavior.

### Tests

- Add async coverage asserting omitted nonce uses `get_account_next_index()` and does not call `get_account_nonce()`.
- Add sync coverage asserting omitted nonce uses `get_account_next_index()` and does not call `get_account_nonce()`.
- Add async and sync coverage asserting explicit `nonce=` values do not call `get_account_next_index()`.

## Test plan

- [x] `python3 -m py_compile async_substrate_interface/async_substrate.py async_substrate_interface/sync_substrate.py tests/unit_tests/asyncio_/test_substrate_interface_async_unit.py tests/unit_tests/sync/test_substrate_interface_sync_unit.py`
- [x] Focused pytest set — 7 passed

## Risk / compatibility

- Explicit `nonce=` behavior is unchanged.
- The behavior change only applies when the library auto-fills the nonce.
- This makes the default path pending-aware and avoids stale or duplicate nonce submissions when an account already has pending extrinsics.

