### PR TITLE
fix: Avoid replaying extrinsic submission RPCs on reconnect

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -95,6 +95,12 @@ ResultHandler = Callable[[dict, Any], Awaitable[tuple[dict, bool]]]
 
 logger = logging.getLogger("async_substrate_interface")
 raw_websocket_logger = logging.getLogger("raw_websocket")
+NON_REPLAYABLE_RPC_METHODS = frozenset(
+    {
+        "author_submitExtrinsic",
+        "author_submitAndWatchExtrinsic",
+    }
+)
 
 # env vars dictating the cache size of the cached methods
 SUBSTRATE_CACHE_METHOD_SIZE = int(os.getenv("SUBSTRATE_CACHE_METHOD_SIZE", "512"))
@@ -901,13 +907,7 @@ class Websocket:
                     f"Timeout occurred. Reconnecting. Attempt {self._attempts} of {self._max_retries}"
                 )
 
-            async with self._lock:
-                for original_id in list(self._inflight.keys()):
-                    payload = self._inflight.pop(original_id)
-                    self._received[original_id] = loop.create_future()
-                    to_send = json.loads(payload)
-                    logger.debug(f"Resubmitting {to_send['id']}")
-                    await self._sending.put(to_send)
+            await self._requeue_replay_safe_inflight(loop)
 
             logger.debug("Attempting reconnection...")
             await self.connect(True)
@@ -925,6 +925,43 @@ class Websocket:
                 "Ensure these are unsubscribed from before closing in the future."
             )
         return None
+
+    @staticmethod
+    def _is_replay_safe_payload(payload: dict) -> bool:
+        return payload.get("method") not in NON_REPLAYABLE_RPC_METHODS
+
+    @staticmethod
+    def _non_replayable_error(payload: dict) -> SubstrateRequestException:
+        method = payload.get("method", "<unknown>")
+        return SubstrateRequestException(
+            f"RPC request {method} was in-flight when the websocket connection "
+            "timed out or disconnected. The request may already have been "
+            "accepted by the node, so it will not be replayed automatically."
+        )
+
+    async def _requeue_replay_safe_inflight(self, loop: asyncio.AbstractEventLoop):
+        async with self._lock:
+            for original_id in list(self._inflight.keys()):
+                payload = self._inflight.pop(original_id)
+                to_send = json.loads(payload)
+
+                if not self._is_replay_safe_payload(to_send):
+                    logger.debug(
+                        "Refusing to replay non-idempotent in-flight RPC "
+                        f"{to_send.get('method')} with id {to_send.get('id')}"
+                    )
+                    future = self._received.get(original_id)
+                    if future is None:
+                        future = loop.create_future()
+                        self._received[original_id] = future
+                    if not future.done():
+                        future.set_exception(self._non_replayable_error(to_send))
+                    self._in_use_ids.discard(original_id)
+                    continue
+
+                self._received[original_id] = loop.create_future()
+                logger.debug(f"Resubmitting {to_send['id']}")
+                await self._sending.put(to_send)
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if self.shutdown_timer is not None:

--- a/tests/unit_tests/asyncio_/test_substrate_interface_async_unit.py
+++ b/tests/unit_tests/asyncio_/test_substrate_interface_async_unit.py
@@ -1,3 +1,5 @@
+import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock, ANY
 
 import pytest
@@ -7,6 +9,7 @@ from async_substrate_interface.async_substrate import (
     AsyncExtrinsicReceipt,
     AsyncQueryMapResult,
     AsyncSubstrateInterface,
+    Websocket,
 )
 from async_substrate_interface.errors import SubstrateRequestException
 
@@ -244,6 +247,57 @@ async def test_get_account_next_index_bypass_mode_raises_on_rpc_error():
             "5F3sa2TJAWMqDhXG6jhV4N8ko9NoFz5Y2s8vS8uM9f7v7mA",
             use_cache=False,
         )
+
+
+@pytest.mark.asyncio
+async def test_websocket_requeues_replay_safe_inflight_rpc():
+    ws = Websocket("ws://localhost")
+    loop = asyncio.get_running_loop()
+    original_future = loop.create_future()
+    payload = {
+        "jsonrpc": "2.0",
+        "id": "rpc-id",
+        "method": "chain_getHeader",
+        "params": [],
+    }
+    ws._inflight["rpc-id"] = json.dumps(payload)
+    ws._received["rpc-id"] = original_future
+    ws._in_use_ids.add("rpc-id")
+
+    await ws._requeue_replay_safe_inflight(loop)
+
+    assert "rpc-id" not in ws._inflight
+    assert ws._received["rpc-id"] is not original_future
+    assert ws._in_use_ids == {"rpc-id"}
+    assert await ws._sending.get() == payload
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["author_submitExtrinsic", "author_submitAndWatchExtrinsic"],
+)
+@pytest.mark.asyncio
+async def test_websocket_does_not_replay_non_idempotent_inflight_rpc(method):
+    ws = Websocket("ws://localhost")
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+    payload = {
+        "jsonrpc": "2.0",
+        "id": "rpc-id",
+        "method": method,
+        "params": ["0xdeadbeef"],
+    }
+    ws._inflight["rpc-id"] = json.dumps(payload)
+    ws._received["rpc-id"] = future
+    ws._in_use_ids.add("rpc-id")
+
+    await ws._requeue_replay_safe_inflight(loop)
+
+    assert "rpc-id" not in ws._inflight
+    assert ws._sending.empty()
+    assert "rpc-id" not in ws._in_use_ids
+    with pytest.raises(SubstrateRequestException, match=method):
+        future.result()
 
 
 class TestAsyncExtrinsicReceiptProcessEvents:


### PR DESCRIPTION
## Summary

Websocket reconnect handling replayed every in-flight RPC payload after a timeout or disconnect. That is fine for read-style RPCs, but unsafe for write-style extrinsic submission RPCs because the node may already have accepted the first request.

This PR keeps automatic replay for replay-safe RPCs, but refuses to replay:

- `author_submitExtrinsic`
- `author_submitAndWatchExtrinsic`

Instead, the waiting request now receives an explicit `SubstrateRequestException` explaining that the request may already have been accepted and will not be replayed automatically.

## Related

Fixes https://github.com/latent-to/async-substrate-interface/issues/346

## Affected call sites

- **`Websocket._handler`** (`async_substrate.py`) — reconnect replay now delegates to a replay-safety filter.
- **`Websocket._requeue_replay_safe_inflight`** (`async_substrate.py`) — requeues replay-safe in-flight RPCs and errors non-replayable write RPCs.
- **`AsyncSubstrateInterface.submit_extrinsic`** (`async_substrate.py`) — indirectly affected because its submit methods use `author_submitExtrinsic` / `author_submitAndWatchExtrinsic`.

## Changes

### `async_substrate_interface/async_substrate.py`

- Add `NON_REPLAYABLE_RPC_METHODS` for extrinsic submission RPCs.
- Preserve replay behavior for read-style in-flight RPC payloads.
- Refuse to replay in-flight extrinsic submission payloads after timeout/disconnect.
- Complete the original waiting future with `SubstrateRequestException` for non-replayed write RPCs.

### Tests

- Add coverage that a replay-safe in-flight RPC is still requeued.
- Add coverage that `author_submitExtrinsic` is not requeued and raises an explicit error.
- Add coverage that `author_submitAndWatchExtrinsic` is not requeued and raises an explicit error.

## Test plan

- [x] `python3 -m py_compile async_substrate_interface/async_substrate.py tests/unit_tests/asyncio_/test_substrate_interface_async_unit.py`
- [x] Focused pytest set — 3 passed

## Risk / compatibility

- Read-style RPC retry behavior is preserved.
- Extrinsic submission retry behavior changes only after timeout/disconnect while the RPC is in-flight.
- This avoids duplicate submission attempts when the client cannot prove whether the original write request reached the node.
