### PR TITLE
Cache inflight current chain-head requests

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -4288,7 +4288,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
     async def get_block_number(self, block_hash: Optional[str] = None) -> int:
         """Async version of `substrateinterface.base.get_block_number` method."""
         if block_hash is None:
-            return await self._get_block_number(None)
+            return await self._get_current_block_number()
         if (block := self.runtime_cache.blocks_reverse.get(block_hash)) is not None:
             return block
         block = await self._cached_get_block_number(block_hash)
@@ -4302,6 +4302,11 @@ class AsyncSubstrateInterface(SubstrateMixin):
         as is the case with DiskCachedAsyncSubstrateInterface._cached_get_block_number
         """
         return await self._get_block_number(block_hash=block_hash)
+
+    @cached_fetcher(cache_key_index=None, cache_results=False)
+    async def _get_current_block_number(self) -> int:
+        response = await self.rpc_request("chain_getHeader", [None])
+        return int(response["result"]["number"], 16)
 
     async def _get_block_number(self, block_hash: Optional[str]) -> int:
         response = await self.rpc_request("chain_getHeader", [block_hash])

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -2817,8 +2817,17 @@ class AsyncSubstrateInterface(SubstrateMixin):
     async def _get_block_hash(self, block_id: Optional[int]) -> str:
         return (await self.rpc_request("chain_getBlockHash", [block_id]))["result"]
 
-    @cached_fetcher(cache_key_index=None, cache_results=False)
     async def get_chain_head(self) -> str:
+        return await self._cached_get_chain_head()
+
+    @cached_fetcher(cache_key_index=None, cache_results=False)
+    async def _cached_get_chain_head(self) -> str:
+        """
+        Resolves the chaintip. Decorated as a dedup-only fetcher (never memoized, since the
+        chaintip goes stale) so that concurrent callers share a single `chain_getHead` request.
+        Kept separate from the public `get_chain_head` so the latter stays a plain coroutine
+        method — friendlier to introspection/mocking by downstream consumers.
+        """
         response = await self._make_rpc_request(
             [
                 self.make_payload(
@@ -3269,7 +3278,6 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
         return extrinsic
 
-    @cached_fetcher(cache_key_index=None, cache_results=False)
     async def get_chain_finalised_head(self) -> str:
         """
         A pass-though to existing JSONRPC method `chain_getFinalizedHead`
@@ -3277,6 +3285,12 @@ class AsyncSubstrateInterface(SubstrateMixin):
         Returns:
             Hash of the most-recently finalized block
         """
+        return await self._cached_get_chain_finalised_head()
+
+    @cached_fetcher(cache_key_index=None, cache_results=False)
+    async def _cached_get_chain_finalised_head(self) -> str:
+        # Dedup-only fetcher (see `_cached_get_chain_head`): the finalized head advances, so it
+        # is never memoized, but concurrent callers still share a single request.
         response = await self.rpc_request("chain_getFinalizedHead", [])
         return response["result"]
 

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -2817,6 +2817,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
     async def _get_block_hash(self, block_id: Optional[int]) -> str:
         return (await self.rpc_request("chain_getBlockHash", [block_id]))["result"]
 
+    @cached_fetcher(cache_key_index=None, cache_results=False)
     async def get_chain_head(self) -> str:
         response = await self._make_rpc_request(
             [
@@ -3268,6 +3269,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
         return extrinsic
 
+    @cached_fetcher(cache_key_index=None, cache_results=False)
     async def get_chain_finalised_head(self) -> str:
         """
         A pass-though to existing JSONRPC method `chain_getFinalizedHead`

--- a/async_substrate_interface/utils/cache.py
+++ b/async_substrate_interface/utils/cache.py
@@ -532,6 +532,7 @@ class CachedFetcher:
         max_size: int,
         method: Callable[..., Awaitable[Any]],
         cache_key_index: Optional[int] = 0,
+        cache_results: bool = True,
     ):
         """
         Args:
@@ -539,12 +540,16 @@ class CachedFetcher:
             method: the function to cache
             cache_key_index: if the method takes multiple args, this is the index of that cache key in the args list
                 (default is the first arg). By setting this to `None`, it will use all args as the cache key.
+            cache_results: whether to memoize results in the LRU cache. When `False`, concurrent calls still share
+                a single in-flight future (so they de-duplicate to one I/O), but the result is never stored — a
+                later call re-fetches. Use this for values that go stale, such as the chaintip from `get_chain_head`.
         """
         self._inflight: dict[Hashable, asyncio.Future] = {}
         self._method = method
         self._max_size = max_size
         self._cache = LRUCache(max_size=max_size)
         self._cache_key_index = cache_key_index
+        self._cache_results = cache_results
 
     def make_cache_key(self, args: tuple, kwargs: dict) -> Hashable:
         bound = inspect.signature(self._method).bind(*args, **kwargs)
@@ -559,7 +564,7 @@ class CachedFetcher:
     async def __call__(self, *args: Any, **kwargs: Any) -> Any:
         key = self.make_cache_key(args, kwargs)
 
-        if item := self._cache.get(key):
+        if self._cache_results and (item := self._cache.get(key)) is not None:
             return item
 
         if key in self._inflight:
@@ -571,7 +576,8 @@ class CachedFetcher:
 
         try:
             result = await self._method(*args, **kwargs)
-            self._cache.set(key, result)
+            if self._cache_results:
+                self._cache.set(key, result)
             future.set_result(result)
             return result
         except Exception:
@@ -609,10 +615,17 @@ class _CachedFetcherMethod:
     Helper class for using CachedFetcher with method caches (rather than functions)
     """
 
-    def __init__(self, method, max_size: int, cache_key_index: int):
+    def __init__(
+        self,
+        method,
+        max_size: int,
+        cache_key_index: int,
+        cache_results: bool = True,
+    ):
         self.method = method
         self.max_size = max_size
         self.cache_key_index = cache_key_index
+        self.cache_results = cache_results
         # Use WeakKeyDictionary to avoid preventing garbage collection of instances
         self._instances: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 
@@ -629,14 +642,19 @@ class _CachedFetcherMethod:
                 max_size=self.max_size,
                 method=weak_method,
                 cache_key_index=self.cache_key_index,
+                cache_results=self.cache_results,
             )
         return self._instances[instance]
 
 
-def cached_fetcher(max_size: Optional[int] = None, cache_key_index: Optional[int] = 0):
+def cached_fetcher(
+    max_size: Optional[int] = None,
+    cache_key_index: Optional[int] = 0,
+    cache_results: bool = True,
+):
     """Wrapper for CachedFetcher. See example in CachedFetcher docstring."""
 
     def wrapper(method):
-        return _CachedFetcherMethod(method, max_size, cache_key_index)
+        return _CachedFetcherMethod(method, max_size, cache_key_index, cache_results)
 
     return wrapper

--- a/tests/unit_tests/asyncio_/test_substrate_interface_async_unit.py
+++ b/tests/unit_tests/asyncio_/test_substrate_interface_async_unit.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, ANY
 
 import pytest
@@ -251,6 +252,54 @@ class TestGetBlockNumber:
         substrate.runtime_cache.add_item.assert_called_once_with(
             block_hash="0xABC", block=100
         )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_block_hash_none_dedups_chain_head_request():
+    """
+    Concurrent operations that resolve the chaintip share a single RPC.
+
+    ``query(..., block_hash=None)`` delegates to ``init_runtime``, which (with no
+    block_hash) resolves the current block via ``get_chain_head``. Because
+    ``get_chain_head`` is a dedup-only cached_fetcher, gathering several such
+    operations should send only ONE ``chain_getHead`` request, not one per call.
+    """
+    substrate = AsyncSubstrateInterface("ws://localhost", _mock=True)
+
+    # Short-circuit init_runtime right after get_chain_head: pretend the runtime for
+    # the resolved version is already cached, so we exercise only the chaintip lookup.
+    substrate.runtime_cache = MagicMock()
+    substrate.runtime_cache.retrieve.return_value = MagicMock(name="runtime")
+    substrate.get_block_runtime_version_for = AsyncMock(return_value=1)
+
+    # Count the actual chain_getHead RPCs. A gate ensures both callers are in-flight
+    # before the first one resolves, so the second must dedup onto the first's future.
+    head_requests = 0
+    release = asyncio.Event()
+
+    async def fake_make_rpc_request(payloads, *args, **kwargs):
+        nonlocal head_requests
+        head_requests += 1
+        await release.wait()
+        return {"rpc_request": [{"result": "0xHEAD"}]}
+
+    substrate._make_rpc_request = fake_make_rpc_request
+
+    task1 = asyncio.create_task(substrate.init_runtime(block_hash=None))
+    task2 = asyncio.create_task(substrate.init_runtime(block_hash=None))
+    await asyncio.sleep(0.1)  # let both reach (and dedup at) get_chain_head
+
+    release.set()
+    await asyncio.gather(task1, task2)
+
+    # Two queries, but only one chain_getHead hit the wire.
+    assert head_requests == 1
+    assert substrate.last_block_hash == "0xHEAD"
+
+    # And once the in-flight batch resolves, the chaintip is NOT memoized: a later
+    # call issues a fresh request (it would otherwise go stale).
+    await substrate.get_chain_head()
+    assert head_requests == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/asyncio_/test_substrate_interface_async_unit.py
+++ b/tests/unit_tests/asyncio_/test_substrate_interface_async_unit.py
@@ -224,14 +224,14 @@ class TestGetBlockNumber:
         s = AsyncSubstrateInterface("ws://localhost", _mock=True)
         s.runtime_cache = MagicMock()
         s._cached_get_block_number = AsyncMock(return_value=100)
-        s._get_block_number = AsyncMock(return_value=99)
+        s._get_current_block_number = AsyncMock(return_value=99)
         return s
 
     @pytest.mark.asyncio
-    async def test_none_block_hash_calls_get_block_number_directly(self, substrate):
+    async def test_none_block_hash_calls_get_current_block_number(self, substrate):
         result = await substrate.get_block_number(None)
         assert result == 99
-        substrate._get_block_number.assert_awaited_once_with(None)
+        substrate._get_current_block_number.assert_awaited_once_with()
         substrate._cached_get_block_number.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/tests/unit_tests/test_cache.py
+++ b/tests/unit_tests/test_cache.py
@@ -2,7 +2,7 @@ import asyncio
 import pytest
 from unittest import mock
 
-from async_substrate_interface.utils.cache import CachedFetcher
+from async_substrate_interface.utils.cache import CachedFetcher, cached_fetcher
 
 
 @pytest.mark.asyncio
@@ -88,3 +88,119 @@ async def test_cached_fetcher_eviction():
     assert "key1" not in fetcher._cache.cache
     assert "key2" in fetcher._cache.cache
     assert "key3" in fetcher._cache.cache
+
+
+@pytest.mark.asyncio
+async def test_cached_fetcher_cache_results_false_does_not_memoize():
+    """With cache_results=False, results are never stored, so each sequential call re-fetches."""
+    calls = 0
+
+    async def method(x):
+        nonlocal calls
+        calls += 1
+        return f"result_{x}_{calls}"
+
+    fetcher = CachedFetcher(max_size=2, method=method, cache_results=False)
+
+    result1 = await fetcher("key1")
+    result2 = await fetcher("key1")
+
+    # The stale value is never memoized, so the second call re-fetches.
+    assert calls == 2
+    assert result1 != result2
+    # Nothing is stored in the LRU.
+    assert len(fetcher._cache.cache) == 0
+
+
+@pytest.mark.asyncio
+async def test_cached_fetcher_cache_results_false_still_dedups_inflight():
+    """With cache_results=False, concurrent calls still share a single in-flight future."""
+    calls = 0
+    event = asyncio.Event()
+
+    async def slow_method(x):
+        nonlocal calls
+        calls += 1
+        await event.wait()
+        return f"slow_{x}_{calls}"
+
+    fetcher = CachedFetcher(max_size=2, method=slow_method, cache_results=False)
+
+    # Two concurrent requests for the same key while the first is in-flight.
+    task1 = asyncio.create_task(fetcher("key1"))
+    task2 = asyncio.create_task(fetcher("key1"))
+    await asyncio.sleep(0.1)
+
+    event.set()
+    result1, result2 = await asyncio.gather(task1, task2)
+
+    # Shared a single I/O despite not being cached.
+    assert result1 == result2 == "slow_key1_1"
+    assert calls == 1
+
+    # The in-flight future is gone, so a later call re-fetches (no memoization).
+    result3 = await fetcher("key1")
+    assert calls == 2
+    assert result3 == "slow_key1_2"
+
+
+@pytest.mark.asyncio
+async def test_cached_fetcher_decorator_no_arg_dedup_only():
+    """Mirrors get_chain_head: a no-arg method that dedups concurrent calls but never memoizes."""
+
+    class Chain:
+        def __init__(self):
+            self.calls = 0
+            self.event = asyncio.Event()
+
+        @cached_fetcher(cache_key_index=None, cache_results=False)
+        async def get_head(self):
+            self.calls += 1
+            await self.event.wait()
+            return f"head_{self.calls}"
+
+    chain = Chain()
+
+    # Concurrent calls collapse to a single I/O.
+    task1 = asyncio.create_task(chain.get_head())
+    task2 = asyncio.create_task(chain.get_head())
+    await asyncio.sleep(0.1)
+    chain.event.set()
+    result1, result2 = await asyncio.gather(task1, task2)
+    assert result1 == result2 == "head_1"
+    assert chain.calls == 1
+
+    # A later call re-fetches the (now stale) chaintip rather than returning a cached value.
+    result3 = await chain.get_head()
+    assert result3 == "head_2"
+    assert chain.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_cached_fetcher_decorator_memoizes_by_default():
+    """The cached_fetcher decorator memoizes per-instance by default (cache_results=True)."""
+
+    class Chain:
+        def __init__(self):
+            self.calls = 0
+
+        @cached_fetcher(max_size=8)
+        async def fetch(self, key):
+            self.calls += 1
+            return f"{key}_{self.calls}"
+
+    chain = Chain()
+    result1 = await chain.fetch("a")
+    result2 = await chain.fetch("a")
+    # Second call with the same key is served from the cache.
+    assert result1 == result2 == "a_1"
+    assert chain.calls == 1
+
+    # A new key triggers a fetch.
+    await chain.fetch("b")
+    assert chain.calls == 2
+
+    # Caches are isolated per-instance.
+    other = Chain()
+    await other.fetch("a")
+    assert other.calls == 1


### PR DESCRIPTION
Adds new functionality to `CachedFetcher` that will not cache the *results* of a request if specified `cache_results=False`.

This may seem to defeat the point, but in fact it does not. This allows using the current request caching, without needing to cache the result.

For example, we wouldn't want to cache `get_block_hash(None)` because the block hash changes often. But if we can utilise the same inflight request for two concurrent requests, we can stop writing:
```py
block_hash = await substrate.get_chain_head()
q1, q2 = await asyncio.gather(
    substrate.query(bar, foo, block_hash=block_hash),
    substrate.query(bat, baz, block_hash=block_hash)
)
```

and instead write the much simpler:
```py
q1, q2 = await asyncio.gather(
    substrate.query(bar, foo),
    substrate.query(bat, baz)
)
```

as both requests internally fetch the chain head, and will utilise the same head fetch request with this new functionality. (See `tests/unit_tests/asyncio_/test_substrate_interface_async_unit.py:test_concurrent_block_hash_none_dedups_chain_head_request`)