### PR TITLE
Bumps version + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.1.0 /2026-06-01
+
+## What's Changed
+
+* Cache inflight current chain-head requests by @thewhaleking
+  in https://github.com/latent-to/async-substrate-interface/pull/357
+* Run bittensor e2e concurrently by @thewhaleking in https://github.com/latent-to/async-substrate-interface/pull/358
+
+**Full Changelog**: https://github.com/latent-to/async-substrate-interface/compare/v2.0.4...v2.1.0
+
 ## 2.0.4 /2026-05-13
 
 ## What's Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "async-substrate-interface"
-version = "2.0.4"
+version = "2.1.0"
 description = "Asyncio library for interacting with substrate. Mostly API-compatible with py-substrate-interface"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## What's Changed
* Cache inflight current chain-head requests by @thewhaleking in https://github.com/latent-to/async-substrate-interface/pull/357
* Run bittensor e2e concurrently by @thewhaleking in https://github.com/latent-to/async-substrate-interface/pull/358


**Full Changelog**: https://github.com/latent-to/async-substrate-interface/compare/v2.0.4...v2.1.0