### PR TITLE
Release/2.1.0

### DIFF
--- a/.github/workflows/check-sdk-tests.yml
+++ b/.github/workflows/check-sdk-tests.yml
@@ -257,7 +257,15 @@ jobs:
       - pull-docker-image
       - build-e2e-image
 
-    if: ${{ !cancelled() && needs.check-labels.outputs.run-sdk-tests == 'true' }}
+    # Only fan out the matrix if every input-producing dependency succeeded — otherwise
+    # all 139 jobs would spawn only to fail (missing image/localnet artifact, or no
+    # test list). !cancelled() alone would let them run on upstream failure.
+    if: >-
+      ${{ !cancelled()
+      && needs.check-labels.outputs.run-sdk-tests == 'true'
+      && needs.find-e2e-tests.result == 'success'
+      && needs.pull-docker-image.result == 'success'
+      && needs.build-e2e-image.result == 'success' }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/check-sdk-tests.yml
+++ b/.github/workflows/check-sdk-tests.yml
@@ -199,12 +199,21 @@ jobs:
           cat > Dockerfile <<'DOCKERFILE'
           FROM python:3.13-slim
 
-          # System deps: build toolchain for any source wheels, the docker CLI so the
-          # e2e fixtures can launch the subtensor-localnet container (docker-out-of-docker),
-          # and git for any VCS-based installs.
+          # System deps: build toolchain for any source wheels, curl for the docker CLI
+          # download below, and git for any VCS-based installs.
           RUN apt-get update && apt-get install -y --no-install-recommends \
-                clang curl libssl-dev llvm libudev-dev protobuf-compiler git docker.io \
+                clang curl libssl-dev llvm libudev-dev protobuf-compiler git \
               && rm -rf /var/lib/apt/lists/*
+
+          # Static Docker CLI (client only). The e2e fixtures shell out to `docker` to
+          # launch the localnet via the mounted host socket; installing the static binary
+          # to /usr/local/bin guarantees it is on PATH regardless of the base distro's
+          # packaging (the `docker.io` apt package did not reliably provide it). The final
+          # `docker --version` fails the build early if the CLI is ever missing.
+          ARG DOCKER_CLI_VERSION=27.5.1
+          RUN curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_CLI_VERSION}.tgz" \
+                | tar -xz -C /usr/local/bin --strip-components=1 docker/docker \
+              && docker --version
 
           RUN pip install --no-cache-dir uv
 
@@ -272,6 +281,21 @@ jobs:
       # docker socket let the e2e fixtures start the localnet (published on the host's
       # :9944) and reach it at ws://localhost:9944. All deps are baked into the image,
       # so there is no per-test apt/clone/install.
+      # Fail loudly (instead of letting the e2e fixture silently skip) if the docker
+      # CLI isn't on PATH, the host daemon isn't reachable through the mounted socket,
+      # or the localnet image didn't load — the three things the `local_chain` fixture
+      # needs before it will actually start a chain.
+      - name: Preflight - verify docker is reachable inside the test container
+        run: |
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            "${{ needs.build-e2e-image.outputs.image }}" \
+            sh -euxc '
+              command -v docker
+              docker version
+              docker image inspect ghcr.io/opentensor/subtensor-localnet:devnet-ready >/dev/null
+            '
+
       - name: Run e2e tests
         run: |
           docker run --rm \

--- a/.github/workflows/check-sdk-tests.yml
+++ b/.github/workflows/check-sdk-tests.yml
@@ -3,7 +3,6 @@ name: Bittensor SDK Test
 permissions:
   pull-requests: write
   contents: read
-  packages: write
 
 concurrency:
   group: e2e-sdk-${{ github.ref }}
@@ -232,15 +231,24 @@ jobs:
 
       - name: Set image ref
         id: meta
-        run: echo "image=ghcr.io/${{ github.repository }}/e2e:${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_OUTPUT
+        # A plain local tag (no registry): the image is shipped to the matrix jobs as a
+        # `docker save` tarball artifact, not via a registry push.
+        run: echo "image=async-substrate-interface-e2e:${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_OUTPUT
 
-      - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+      - name: Build image
+        run: docker build -t "${{ steps.meta.outputs.image }}" .
 
-      - name: Build and push image
-        run: |
-          docker build -t "${{ steps.meta.outputs.image }}" .
-          docker push "${{ steps.meta.outputs.image }}"
+      - name: Save image to tarball
+        # Distribute via a GitHub artifact (fast internal transport, same as the localnet
+        # image) instead of GHCR, which avoids slow registry pulls across all matrix jobs,
+        # registry rate-limits, and the fork-PR push-permission problem.
+        run: docker save -o e2e-image.tar "${{ steps.meta.outputs.image }}"
+
+      - name: Upload image as artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-image
+          path: e2e-image.tar
 
   run-e2e-tests:
     needs:
@@ -261,11 +269,13 @@ jobs:
     timeout-minutes: 60
     name: "e2e tests: ${{ matrix.test-case }}"
     steps:
-      - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+      - name: Download prebuilt test image
+        uses: actions/download-artifact@v8
+        with:
+          name: e2e-image
 
-      - name: Pull prebuilt test image
-        run: docker pull "${{ needs.build-e2e-image.outputs.image }}"
+      - name: Load prebuilt test image
+        run: docker load -i e2e-image.tar
 
       - name: Download Cached Docker Image
         uses: actions/download-artifact@v8

--- a/.github/workflows/check-sdk-tests.yml
+++ b/.github/workflows/check-sdk-tests.yml
@@ -3,6 +3,7 @@ name: Bittensor SDK Test
 permissions:
   pull-requests: write
   contents: read
+  packages: write
 
 concurrency:
   group: e2e-sdk-${{ github.ref }}
@@ -155,14 +156,104 @@ jobs:
           name: subtensor-localnet
           path: subtensor-localnet.tar
 
+  build-e2e-image:
+    # Build the test environment (system deps + bittensor[dev] + this PR's
+    # async-substrate-interface) into a single image ONCE per run, so the e2e
+    # matrix jobs below just pull it and run pytest — no per-test setup.
+    needs:
+      - check-labels
+    if: always() && needs.check-labels.outputs.run-sdk-tests == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - name: Clone Bittensor SDK repo
+        run: git clone https://github.com/latent-to/bittensor.git
+
+      - name: Checkout Bittensor branch
+        working-directory: ${{ github.workspace }}/bittensor
+        run: |
+          if ! git fetch origin $BITTENSOR_BRANCH; then
+            echo "❌ Error: Branch '$BITTENSOR_BRANCH' does not exist in latent-to/bittensor."
+            exit 1
+          fi
+          git checkout FETCH_HEAD
+          echo "✅ Using Bittensor branch: $BITTENSOR_BRANCH"
+
+      - name: Clone async-substrate-interface repo
+        run: git clone https://github.com/latent-to/async-substrate-interface.git
+
+      - name: Checkout PR branch in async-substrate-interface
+        working-directory: ${{ github.workspace }}/async-substrate-interface
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref || github.ref_name }}"
+          REPO_URL="${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/latent-to/async-substrate-interface.git' }}"
+          git fetch $REPO_URL $BRANCH
+          git checkout FETCH_HEAD
+          echo "Current SHA: $(git rev-parse HEAD)"
+
+      - name: Write Dockerfile
+        run: |
+          # Exclude the (large) .git dirs from the build context.
+          printf '**/.git\n' > .dockerignore
+          cat > Dockerfile <<'DOCKERFILE'
+          FROM python:3.13-slim
+
+          # System deps: build toolchain for any source wheels, the docker CLI so the
+          # e2e fixtures can launch the subtensor-localnet container (docker-out-of-docker),
+          # and git for any VCS-based installs.
+          RUN apt-get update && apt-get install -y --no-install-recommends \
+                clang curl libssl-dev llvm libudev-dev protobuf-compiler git docker.io \
+              && rm -rf /var/lib/apt/lists/*
+
+          RUN pip install --no-cache-dir uv
+
+          COPY bittensor /opt/bittensor
+          COPY async-substrate-interface /opt/async-substrate-interface
+
+          # Install the SDK with dev extras, then overlay this PR's build of
+          # async-substrate-interface so the tests exercise the PR code.
+          RUN uv pip install --system '/opt/bittensor[dev]' \
+              && (uv pip uninstall --system async-substrate-interface || true) \
+              && uv pip install --system /opt/async-substrate-interface
+
+          # pytest is invoked from here so the relative `tests/e2e_tests/...` node ids resolve.
+          WORKDIR /opt/bittensor
+          DOCKERFILE
+
+      - name: Set image ref
+        id: meta
+        run: echo "image=ghcr.io/${{ github.repository }}/e2e:${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_OUTPUT
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+
+      - name: Build and push image
+        run: |
+          docker build -t "${{ steps.meta.outputs.image }}" .
+          docker push "${{ steps.meta.outputs.image }}"
+
   run-e2e-tests:
     needs:
       - check-labels
       - find-e2e-tests
       - pull-docker-image
+      - build-e2e-image
 
     if: always() && needs.check-labels.outputs.run-sdk-tests == 'true'
     runs-on: ubuntu-latest
+
+    # Run each test inside the prebuilt image: all deps are already installed, so
+    # there is no per-test apt/clone/install. Docker-out-of-docker (mounted host
+    # socket) + host networking let the e2e fixtures launch the localnet container
+    # and reach it at ws://localhost:9944, just as on a bare runner.
+    container:
+      image: ${{ needs.build-e2e-image.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --network host -v /var/run/docker.sock:/var/run/docker.sock
+
     strategy:
       fail-fast: false
       max-parallel: 16
@@ -170,11 +261,9 @@ jobs:
         test-case: ${{ fromJson(needs.find-e2e-tests.outputs.test-cases) }}
 
     env:
-      RELEASE_NAME: development
-      RUSTV: ${{ matrix.rust-branch }}
-      RUST_BACKTRACE: full
-      RUST_BIN_DIR: target/${{ matrix.rust-target }}
-      TARGET: ${{ matrix.rust-target }}
+      # The localnet image is preloaded from the cached tar below; skip the
+      # fixture's own `docker pull`.
+      SKIP_PULL: "1"
 
     timeout-minutes: 60
     name: "e2e tests: ${{ matrix.test-case }}"

--- a/.github/workflows/check-sdk-tests.yml
+++ b/.github/workflows/check-sdk-tests.yml
@@ -243,31 +243,21 @@ jobs:
     if: always() && needs.check-labels.outputs.run-sdk-tests == 'true'
     runs-on: ubuntu-latest
 
-    # Run each test inside the prebuilt image: all deps are already installed, so
-    # there is no per-test apt/clone/install. Docker-out-of-docker (mounted host
-    # socket) + host networking let the e2e fixtures launch the localnet container
-    # and reach it at ws://localhost:9944, just as on a bare runner.
-    container:
-      image: ${{ needs.build-e2e-image.outputs.image }}
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-      options: --network host -v /var/run/docker.sock:/var/run/docker.sock
-
     strategy:
       fail-fast: false
       max-parallel: 16
       matrix:
         test-case: ${{ fromJson(needs.find-e2e-tests.outputs.test-cases) }}
 
-    env:
-      # The localnet image is preloaded from the cached tar below; skip the
-      # fixture's own `docker pull`.
-      SKIP_PULL: "1"
-
     timeout-minutes: 60
     name: "e2e tests: ${{ matrix.test-case }}"
     steps:
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+
+      - name: Pull prebuilt test image
+        run: docker pull "${{ needs.build-e2e-image.outputs.image }}"
+
       - name: Download Cached Docker Image
         uses: actions/download-artifact@v8
         with:
@@ -276,9 +266,21 @@ jobs:
       - name: Load Docker Image
         run: docker load -i subtensor-localnet.tar
 
+      # The job stays on the bare runner (no `container:`), so we can launch the test
+      # container ourselves with `--network host` — GitHub injects its own network into
+      # job containers, which conflicts with host mode. Host networking + the mounted
+      # docker socket let the e2e fixtures start the localnet (published on the host's
+      # :9944) and reach it at ws://localhost:9944. All deps are baked into the image,
+      # so there is no per-test apt/clone/install.
       - name: Run e2e tests
-        working-directory: /opt/bittensor
-        run: pytest "${{ matrix.test-case }}" -s
+        run: |
+          docker run --rm \
+            --network host \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -w /opt/bittensor \
+            -e SKIP_PULL=1 \
+            "${{ needs.build-e2e-image.outputs.image }}" \
+            pytest "${{ matrix.test-case }}" -s
 
 
   run-integration-and-unit-test:

--- a/.github/workflows/check-sdk-tests.yml
+++ b/.github/workflows/check-sdk-tests.yml
@@ -254,7 +254,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 16
+      max-parallel: 64
       matrix:
         test-case: ${{ fromJson(needs.find-e2e-tests.outputs.test-cases) }}
 
@@ -281,21 +281,6 @@ jobs:
       # docker socket let the e2e fixtures start the localnet (published on the host's
       # :9944) and reach it at ws://localhost:9944. All deps are baked into the image,
       # so there is no per-test apt/clone/install.
-      # Fail loudly (instead of letting the e2e fixture silently skip) if the docker
-      # CLI isn't on PATH, the host daemon isn't reachable through the mounted socket,
-      # or the localnet image didn't load — the three things the `local_chain` fixture
-      # needs before it will actually start a chain.
-      - name: Preflight - verify docker is reachable inside the test container
-        run: |
-          docker run --rm \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            "${{ needs.build-e2e-image.outputs.image }}" \
-            sh -euxc '
-              command -v docker
-              docker version
-              docker image inspect ghcr.io/opentensor/subtensor-localnet:devnet-ready >/dev/null
-            '
-
       - name: Run e2e tests
         run: |
           docker run --rm \

--- a/.github/workflows/check-sdk-tests.yml
+++ b/.github/workflows/check-sdk-tests.yml
@@ -91,7 +91,7 @@ jobs:
     if: always() && needs.check-labels.outputs.run-sdk-tests == 'true'
     runs-on: ubuntu-latest
     outputs:
-      test-files: ${{ steps.get-tests.outputs.test-files }}
+      test-cases: ${{ steps.get-tests.outputs.test-cases }}
     steps:
       - name: Research preparation
         working-directory: ${{ github.workspace }}
@@ -110,11 +110,26 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install -y jq
 
-      - name: Find e2e test files
+      - name: Find e2e test cases
         id: get-tests
         run: |
-          test_files=$(find ${{ github.workspace }}/bittensor/tests/e2e_tests -name "test*.py" | jq -R -s -c 'split("\n") | map(select(. != ""))')
-          echo "test-files=$test_files" >> $GITHUB_OUTPUT
+          # Emit one matrix entry per individual test function (as a `path::test_name`
+          # node id) rather than per file, so each test gets its own concurrent job.
+          # The e2e suite has no test classes, so grepping top-level `def test_*` is
+          # sufficient and keeps this job dependency-free (no pytest collection needed).
+          # Node ids are relative to the bittensor repo root so they resolve inside the
+          # prebuilt image (where bittensor lives at /opt/bittensor), not the workspace.
+          cd "${{ github.workspace }}/bittensor"
+          test_cases=$(
+            while IFS= read -r f; do
+              grep -oE '^(async[[:space:]]+)?def[[:space:]]+test_[A-Za-z0-9_]+' "$f" \
+                | grep -oE 'test_[A-Za-z0-9_]+' \
+                | while IFS= read -r name; do printf '%s::%s\n' "$f" "$name"; done
+            done < <(find tests/e2e_tests -name "test*.py") \
+              | jq -R -s -c 'split("\n") | map(select(. != ""))'
+          )
+          echo "Collected $(echo "$test_cases" | jq 'length') test cases"
+          echo "test-cases=$test_cases" >> $GITHUB_OUTPUT
         shell: bash
 
   pull-docker-image:
@@ -152,13 +167,7 @@ jobs:
       fail-fast: false
       max-parallel: 16
       matrix:
-        rust-branch:
-          - stable
-        rust-target:
-          - x86_64-unknown-linux-gnu
-        os:
-          - ubuntu-latest
-        test-file: ${{ fromJson(needs.find-e2e-tests.outputs.test-files) }}
+        test-case: ${{ fromJson(needs.find-e2e-tests.outputs.test-cases) }}
 
     env:
       RELEASE_NAME: development
@@ -168,59 +177,8 @@ jobs:
       TARGET: ${{ matrix.rust-target }}
 
     timeout-minutes: 60
-    name: "e2e tests: ${{ matrix.test-file }}"
+    name: "e2e tests: ${{ matrix.test-case }}"
     steps:
-      - name: Check-out repository
-        uses: actions/checkout@v6
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update &&
-          sudo apt-get install -y clang curl libssl-dev llvm libudev-dev protobuf-compiler
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-
-      - name: Clone Bittensor SDK repo
-        run: git clone https://github.com/latent-to/bittensor.git
-
-      - name: Checkout Bittensor branch
-        working-directory: ${{ github.workspace }}/bittensor
-        run: |
-          if ! git fetch origin $BITTENSOR_BRANCH; then
-            echo "❌ Error: Branch '$BITTENSOR_BRANCH' does not exist in latent-to/bittensor."
-            exit 1
-          fi
-          git checkout FETCH_HEAD
-          echo "✅ Using Bittensor branch: $BITTENSOR_BRANCH"
-
-      - name: Install Bittensor SDK dependencies
-        working-directory: ${{ github.workspace }}/bittensor
-        run: uv pip install --system '.[dev]'
-
-      - name: Clone async-substrate-interface repo
-        run: git clone https://github.com/latent-to/async-substrate-interface.git
-
-      - name: Checkout PR branch in async-substrate-interface
-        working-directory: ${{ github.workspace }}/async-substrate-interface
-        run: |
-          BRANCH="${{ github.event.pull_request.head.ref || github.ref_name }}"
-          REPO_URL="${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/latent-to/async-substrate-interface.git' }}"
-          git fetch $REPO_URL $BRANCH
-          git checkout FETCH_HEAD
-          echo "Current SHA: $(git rev-parse HEAD)"
-
-      - name: Install async-substrate-interface with dev dependencies
-        working-directory: ${{ github.workspace }}/async-substrate-interface
-        run: |
-          uv pip uninstall --system async-substrate-interface || true
-          uv pip install --system '.[dev]'
-
       - name: Download Cached Docker Image
         uses: actions/download-artifact@v8
         with:
@@ -230,7 +188,8 @@ jobs:
         run: docker load -i subtensor-localnet.tar
 
       - name: Run e2e tests
-        run: pytest ${{ matrix.test-file }} -s
+        working-directory: /opt/bittensor
+        run: pytest "${{ matrix.test-case }}" -s
 
 
   run-integration-and-unit-test:

--- a/.github/workflows/check-sdk-tests.yml
+++ b/.github/workflows/check-sdk-tests.yml
@@ -292,6 +292,10 @@ jobs:
       # :9944) and reach it at ws://localhost:9944. All deps are baked into the image,
       # so there is no per-test apt/clone/install.
       - name: Run e2e tests
+        # --reruns retries a flaky test (e.g. when the localnet is listening but its RPC
+        # isn't ready yet, surfacing as a websocket InvalidMessage during connect). The
+        # whole test reruns, re-spinning the localnet fixture, so by the retry the node
+        # is ready. pytest-rerunfailures ships with bittensor[dev].
         run: |
           docker run --rm \
             --network host \
@@ -299,7 +303,7 @@ jobs:
             -w /opt/bittensor \
             -e SKIP_PULL=1 \
             "${{ needs.build-e2e-image.outputs.image }}" \
-            pytest "${{ matrix.test-case }}" -s
+            pytest "${{ matrix.test-case }}" -s --reruns 2 --reruns-delay 5
 
 
   run-integration-and-unit-test:

--- a/.github/workflows/check-sdk-tests.yml
+++ b/.github/workflows/check-sdk-tests.yml
@@ -55,7 +55,7 @@ jobs:
   check-labels:
     needs: apply-label-to-new-pr
     runs-on: ubuntu-latest
-    if: always()
+    if: ${{ !cancelled() }}
     outputs:
       run-sdk-tests: ${{ steps.check-manual.outputs.run-sdk-tests || steps.get-labels-pr.outputs.run-sdk-tests }}
     steps:
@@ -88,7 +88,7 @@ jobs:
 
   find-e2e-tests:
     needs: check-labels
-    if: always() && needs.check-labels.outputs.run-sdk-tests == 'true'
+    if: ${{ !cancelled() && needs.check-labels.outputs.run-sdk-tests == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       test-cases: ${{ steps.get-tests.outputs.test-cases }}
@@ -138,7 +138,7 @@ jobs:
       - find-e2e-tests
 
     runs-on: ubuntu-latest
-    if: always() && needs.check-labels.outputs.run-sdk-tests == 'true'
+    if: ${{ !cancelled() && needs.check-labels.outputs.run-sdk-tests == 'true' }}
     steps:
       - name: Log in to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
@@ -161,7 +161,7 @@ jobs:
     # matrix jobs below just pull it and run pytest — no per-test setup.
     needs:
       - check-labels
-    if: always() && needs.check-labels.outputs.run-sdk-tests == 'true'
+    if: ${{ !cancelled() && needs.check-labels.outputs.run-sdk-tests == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.meta.outputs.image }}
@@ -257,7 +257,7 @@ jobs:
       - pull-docker-image
       - build-e2e-image
 
-    if: always() && needs.check-labels.outputs.run-sdk-tests == 'true'
+    if: ${{ !cancelled() && needs.check-labels.outputs.run-sdk-tests == 'true' }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -309,7 +309,7 @@ jobs:
   run-integration-and-unit-test:
     needs:
       - check-labels
-    if: always() && needs.check-labels.outputs.run-sdk-tests == 'true'
+    if: ${{ !cancelled() && needs.check-labels.outputs.run-sdk-tests == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check-out repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.1.0 /2026-06-01
+
+## What's Changed
+
+* Cache inflight current chain-head requests by @thewhaleking
+  in https://github.com/latent-to/async-substrate-interface/pull/357
+* Run bittensor e2e concurrently by @thewhaleking in https://github.com/latent-to/async-substrate-interface/pull/358
+
+**Full Changelog**: https://github.com/latent-to/async-substrate-interface/compare/v2.0.4...v2.1.0
+
 ## 2.0.4 /2026-05-13
 
 ## What's Changed

--- a/README.md
+++ b/README.md
@@ -150,6 +150,29 @@ see [GitHub's documentation on signing commits](https://docs.github.com/en/authe
 
 > **Note:** Pull requests containing unsigned commits will not be merged.
 
+## Cyscale Installation Issue
+
+Because cyscale uses the same namespace as py-scale-codec (scalecodec), there can be some difficulties with
+upgrades.
+
+First try the basic
+
+```shell
+pip uninstall scalecodec cyscale -y
+pip install -U cyscale --force-reinstall
+```
+
+If this does not work, it usually means you have other dependent packages (usually bittensor and/or bittensor-cli).
+Reinstalling these should resolve your issues:
+
+```shell
+pip uninstall scalecodec cyscale bittensor bittensor-cli -y
+# only one of the following is required
+pip install -U bittensor[cli] --force-reinstall  # for both bittensor SDK and CLI
+pip install -U bittensor-cli --force-reinstall   # for just bittensor CLI (btcli)
+pip install -U bittensor --force-reinstall       # for just bittensor SDK
+```
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/async_substrate_interface/__init__.py
+++ b/async_substrate_interface/__init__.py
@@ -17,6 +17,8 @@ def _check_conflicts():
             "    pip uninstall scalecodec cyscale -y\n\n"
             "Then reinstall cyscale:\n"
             "    pip install cyscale --force-reinstall\n"
+            "If this does not work, consult the documentation: "
+            "https://github.com/latent-to/async-substrate-interface/blob/master/README.md#cysaleinstallationissue\n"
         )
     except importlib.metadata.PackageNotFoundError:
         pass  # Good — scalecodec is not installed

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -4288,7 +4288,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
     async def get_block_number(self, block_hash: Optional[str] = None) -> int:
         """Async version of `substrateinterface.base.get_block_number` method."""
         if block_hash is None:
-            return await self._get_block_number(None)
+            return await self._get_current_block_number()
         if (block := self.runtime_cache.blocks_reverse.get(block_hash)) is not None:
             return block
         block = await self._cached_get_block_number(block_hash)
@@ -4302,6 +4302,11 @@ class AsyncSubstrateInterface(SubstrateMixin):
         as is the case with DiskCachedAsyncSubstrateInterface._cached_get_block_number
         """
         return await self._get_block_number(block_hash=block_hash)
+
+    @cached_fetcher(cache_key_index=None, cache_results=False)
+    async def _get_current_block_number(self) -> int:
+        response = await self.rpc_request("chain_getHeader", [None])
+        return int(response["result"]["number"], 16)
 
     async def _get_block_number(self, block_hash: Optional[str]) -> int:
         response = await self.rpc_request("chain_getHeader", [block_hash])

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -2817,8 +2817,17 @@ class AsyncSubstrateInterface(SubstrateMixin):
     async def _get_block_hash(self, block_id: Optional[int]) -> str:
         return (await self.rpc_request("chain_getBlockHash", [block_id]))["result"]
 
-    @cached_fetcher(cache_key_index=None, cache_results=False)
     async def get_chain_head(self) -> str:
+        return await self._cached_get_chain_head()
+
+    @cached_fetcher(cache_key_index=None, cache_results=False)
+    async def _cached_get_chain_head(self) -> str:
+        """
+        Resolves the chaintip. Decorated as a dedup-only fetcher (never memoized, since the
+        chaintip goes stale) so that concurrent callers share a single `chain_getHead` request.
+        Kept separate from the public `get_chain_head` so the latter stays a plain coroutine
+        method — friendlier to introspection/mocking by downstream consumers.
+        """
         response = await self._make_rpc_request(
             [
                 self.make_payload(
@@ -3269,7 +3278,6 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
         return extrinsic
 
-    @cached_fetcher(cache_key_index=None, cache_results=False)
     async def get_chain_finalised_head(self) -> str:
         """
         A pass-though to existing JSONRPC method `chain_getFinalizedHead`
@@ -3277,6 +3285,12 @@ class AsyncSubstrateInterface(SubstrateMixin):
         Returns:
             Hash of the most-recently finalized block
         """
+        return await self._cached_get_chain_finalised_head()
+
+    @cached_fetcher(cache_key_index=None, cache_results=False)
+    async def _cached_get_chain_finalised_head(self) -> str:
+        # Dedup-only fetcher (see `_cached_get_chain_head`): the finalized head advances, so it
+        # is never memoized, but concurrent callers still share a single request.
         response = await self.rpc_request("chain_getFinalizedHead", [])
         return response["result"]
 

--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -2817,6 +2817,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
     async def _get_block_hash(self, block_id: Optional[int]) -> str:
         return (await self.rpc_request("chain_getBlockHash", [block_id]))["result"]
 
+    @cached_fetcher(cache_key_index=None, cache_results=False)
     async def get_chain_head(self) -> str:
         response = await self._make_rpc_request(
             [
@@ -3268,6 +3269,7 @@ class AsyncSubstrateInterface(SubstrateMixin):
 
         return extrinsic
 
+    @cached_fetcher(cache_key_index=None, cache_results=False)
     async def get_chain_finalised_head(self) -> str:
         """
         A pass-though to existing JSONRPC method `chain_getFinalizedHead`

--- a/async_substrate_interface/utils/cache.py
+++ b/async_substrate_interface/utils/cache.py
@@ -532,6 +532,7 @@ class CachedFetcher:
         max_size: int,
         method: Callable[..., Awaitable[Any]],
         cache_key_index: Optional[int] = 0,
+        cache_results: bool = True,
     ):
         """
         Args:
@@ -539,12 +540,16 @@ class CachedFetcher:
             method: the function to cache
             cache_key_index: if the method takes multiple args, this is the index of that cache key in the args list
                 (default is the first arg). By setting this to `None`, it will use all args as the cache key.
+            cache_results: whether to memoize results in the LRU cache. When `False`, concurrent calls still share
+                a single in-flight future (so they de-duplicate to one I/O), but the result is never stored — a
+                later call re-fetches. Use this for values that go stale, such as the chaintip from `get_chain_head`.
         """
         self._inflight: dict[Hashable, asyncio.Future] = {}
         self._method = method
         self._max_size = max_size
         self._cache = LRUCache(max_size=max_size)
         self._cache_key_index = cache_key_index
+        self._cache_results = cache_results
 
     def make_cache_key(self, args: tuple, kwargs: dict) -> Hashable:
         bound = inspect.signature(self._method).bind(*args, **kwargs)
@@ -559,7 +564,7 @@ class CachedFetcher:
     async def __call__(self, *args: Any, **kwargs: Any) -> Any:
         key = self.make_cache_key(args, kwargs)
 
-        if item := self._cache.get(key):
+        if self._cache_results and (item := self._cache.get(key)) is not None:
             return item
 
         if key in self._inflight:
@@ -571,7 +576,8 @@ class CachedFetcher:
 
         try:
             result = await self._method(*args, **kwargs)
-            self._cache.set(key, result)
+            if self._cache_results:
+                self._cache.set(key, result)
             future.set_result(result)
             return result
         except Exception:
@@ -609,10 +615,17 @@ class _CachedFetcherMethod:
     Helper class for using CachedFetcher with method caches (rather than functions)
     """
 
-    def __init__(self, method, max_size: int, cache_key_index: int):
+    def __init__(
+        self,
+        method,
+        max_size: int,
+        cache_key_index: int,
+        cache_results: bool = True,
+    ):
         self.method = method
         self.max_size = max_size
         self.cache_key_index = cache_key_index
+        self.cache_results = cache_results
         # Use WeakKeyDictionary to avoid preventing garbage collection of instances
         self._instances: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
 
@@ -629,14 +642,19 @@ class _CachedFetcherMethod:
                 max_size=self.max_size,
                 method=weak_method,
                 cache_key_index=self.cache_key_index,
+                cache_results=self.cache_results,
             )
         return self._instances[instance]
 
 
-def cached_fetcher(max_size: Optional[int] = None, cache_key_index: Optional[int] = 0):
+def cached_fetcher(
+    max_size: Optional[int] = None,
+    cache_key_index: Optional[int] = 0,
+    cache_results: bool = True,
+):
     """Wrapper for CachedFetcher. See example in CachedFetcher docstring."""
 
     def wrapper(method):
-        return _CachedFetcherMethod(method, max_size, cache_key_index)
+        return _CachedFetcherMethod(method, max_size, cache_key_index, cache_results)
 
     return wrapper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "async-substrate-interface"
-version = "2.0.4"
+version = "2.1.0"
 description = "Asyncio library for interacting with substrate. Mostly API-compatible with py-substrate-interface"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/unit_tests/asyncio_/test_substrate_interface_async_unit.py
+++ b/tests/unit_tests/asyncio_/test_substrate_interface_async_unit.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, ANY
 
 import pytest
@@ -251,6 +252,54 @@ class TestGetBlockNumber:
         substrate.runtime_cache.add_item.assert_called_once_with(
             block_hash="0xABC", block=100
         )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_block_hash_none_dedups_chain_head_request():
+    """
+    Concurrent operations that resolve the chaintip share a single RPC.
+
+    ``query(..., block_hash=None)`` delegates to ``init_runtime``, which (with no
+    block_hash) resolves the current block via ``get_chain_head``. Because
+    ``get_chain_head`` is a dedup-only cached_fetcher, gathering several such
+    operations should send only ONE ``chain_getHead`` request, not one per call.
+    """
+    substrate = AsyncSubstrateInterface("ws://localhost", _mock=True)
+
+    # Short-circuit init_runtime right after get_chain_head: pretend the runtime for
+    # the resolved version is already cached, so we exercise only the chaintip lookup.
+    substrate.runtime_cache = MagicMock()
+    substrate.runtime_cache.retrieve.return_value = MagicMock(name="runtime")
+    substrate.get_block_runtime_version_for = AsyncMock(return_value=1)
+
+    # Count the actual chain_getHead RPCs. A gate ensures both callers are in-flight
+    # before the first one resolves, so the second must dedup onto the first's future.
+    head_requests = 0
+    release = asyncio.Event()
+
+    async def fake_make_rpc_request(payloads, *args, **kwargs):
+        nonlocal head_requests
+        head_requests += 1
+        await release.wait()
+        return {"rpc_request": [{"result": "0xHEAD"}]}
+
+    substrate._make_rpc_request = fake_make_rpc_request
+
+    task1 = asyncio.create_task(substrate.init_runtime(block_hash=None))
+    task2 = asyncio.create_task(substrate.init_runtime(block_hash=None))
+    await asyncio.sleep(0.1)  # let both reach (and dedup at) get_chain_head
+
+    release.set()
+    await asyncio.gather(task1, task2)
+
+    # Two queries, but only one chain_getHead hit the wire.
+    assert head_requests == 1
+    assert substrate.last_block_hash == "0xHEAD"
+
+    # And once the in-flight batch resolves, the chaintip is NOT memoized: a later
+    # call issues a fresh request (it would otherwise go stale).
+    await substrate.get_chain_head()
+    assert head_requests == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/asyncio_/test_substrate_interface_async_unit.py
+++ b/tests/unit_tests/asyncio_/test_substrate_interface_async_unit.py
@@ -224,14 +224,14 @@ class TestGetBlockNumber:
         s = AsyncSubstrateInterface("ws://localhost", _mock=True)
         s.runtime_cache = MagicMock()
         s._cached_get_block_number = AsyncMock(return_value=100)
-        s._get_block_number = AsyncMock(return_value=99)
+        s._get_current_block_number = AsyncMock(return_value=99)
         return s
 
     @pytest.mark.asyncio
-    async def test_none_block_hash_calls_get_block_number_directly(self, substrate):
+    async def test_none_block_hash_calls_get_current_block_number(self, substrate):
         result = await substrate.get_block_number(None)
         assert result == 99
-        substrate._get_block_number.assert_awaited_once_with(None)
+        substrate._get_current_block_number.assert_awaited_once_with()
         substrate._cached_get_block_number.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/tests/unit_tests/test_cache.py
+++ b/tests/unit_tests/test_cache.py
@@ -2,7 +2,7 @@ import asyncio
 import pytest
 from unittest import mock
 
-from async_substrate_interface.utils.cache import CachedFetcher
+from async_substrate_interface.utils.cache import CachedFetcher, cached_fetcher
 
 
 @pytest.mark.asyncio
@@ -88,3 +88,119 @@ async def test_cached_fetcher_eviction():
     assert "key1" not in fetcher._cache.cache
     assert "key2" in fetcher._cache.cache
     assert "key3" in fetcher._cache.cache
+
+
+@pytest.mark.asyncio
+async def test_cached_fetcher_cache_results_false_does_not_memoize():
+    """With cache_results=False, results are never stored, so each sequential call re-fetches."""
+    calls = 0
+
+    async def method(x):
+        nonlocal calls
+        calls += 1
+        return f"result_{x}_{calls}"
+
+    fetcher = CachedFetcher(max_size=2, method=method, cache_results=False)
+
+    result1 = await fetcher("key1")
+    result2 = await fetcher("key1")
+
+    # The stale value is never memoized, so the second call re-fetches.
+    assert calls == 2
+    assert result1 != result2
+    # Nothing is stored in the LRU.
+    assert len(fetcher._cache.cache) == 0
+
+
+@pytest.mark.asyncio
+async def test_cached_fetcher_cache_results_false_still_dedups_inflight():
+    """With cache_results=False, concurrent calls still share a single in-flight future."""
+    calls = 0
+    event = asyncio.Event()
+
+    async def slow_method(x):
+        nonlocal calls
+        calls += 1
+        await event.wait()
+        return f"slow_{x}_{calls}"
+
+    fetcher = CachedFetcher(max_size=2, method=slow_method, cache_results=False)
+
+    # Two concurrent requests for the same key while the first is in-flight.
+    task1 = asyncio.create_task(fetcher("key1"))
+    task2 = asyncio.create_task(fetcher("key1"))
+    await asyncio.sleep(0.1)
+
+    event.set()
+    result1, result2 = await asyncio.gather(task1, task2)
+
+    # Shared a single I/O despite not being cached.
+    assert result1 == result2 == "slow_key1_1"
+    assert calls == 1
+
+    # The in-flight future is gone, so a later call re-fetches (no memoization).
+    result3 = await fetcher("key1")
+    assert calls == 2
+    assert result3 == "slow_key1_2"
+
+
+@pytest.mark.asyncio
+async def test_cached_fetcher_decorator_no_arg_dedup_only():
+    """Mirrors get_chain_head: a no-arg method that dedups concurrent calls but never memoizes."""
+
+    class Chain:
+        def __init__(self):
+            self.calls = 0
+            self.event = asyncio.Event()
+
+        @cached_fetcher(cache_key_index=None, cache_results=False)
+        async def get_head(self):
+            self.calls += 1
+            await self.event.wait()
+            return f"head_{self.calls}"
+
+    chain = Chain()
+
+    # Concurrent calls collapse to a single I/O.
+    task1 = asyncio.create_task(chain.get_head())
+    task2 = asyncio.create_task(chain.get_head())
+    await asyncio.sleep(0.1)
+    chain.event.set()
+    result1, result2 = await asyncio.gather(task1, task2)
+    assert result1 == result2 == "head_1"
+    assert chain.calls == 1
+
+    # A later call re-fetches the (now stale) chaintip rather than returning a cached value.
+    result3 = await chain.get_head()
+    assert result3 == "head_2"
+    assert chain.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_cached_fetcher_decorator_memoizes_by_default():
+    """The cached_fetcher decorator memoizes per-instance by default (cache_results=True)."""
+
+    class Chain:
+        def __init__(self):
+            self.calls = 0
+
+        @cached_fetcher(max_size=8)
+        async def fetch(self, key):
+            self.calls += 1
+            return f"{key}_{self.calls}"
+
+    chain = Chain()
+    result1 = await chain.fetch("a")
+    result2 = await chain.fetch("a")
+    # Second call with the same key is served from the cache.
+    assert result1 == result2 == "a_1"
+    assert chain.calls == 1
+
+    # A new key triggers a fetch.
+    await chain.fetch("b")
+    assert chain.calls == 2
+
+    # Caches are isolated per-instance.
+    other = Chain()
+    await other.fetch("a")
+    assert other.calls == 1


### PR DESCRIPTION
## 2.1.0 /2026-06-01

## What's Changed

* Cache inflight current chain-head requests by @thewhaleking
  in https://github.com/latent-to/async-substrate-interface/pull/357
* Run bittensor e2e concurrently by @thewhaleking in https://github.com/latent-to/async-substrate-interface/pull/358

**Full Changelog**: https://github.com/latent-to/async-substrate-interface/compare/v2.0.4...v2.1.0
