### PR TITLE
Batch StorageKey creation

### DIFF
--- a/async_substrate_interface/async_substrate.py
+++ b/async_substrate_interface/async_substrate.py
@@ -1702,6 +1702,48 @@ class AsyncSubstrateInterface(SubstrateMixin):
             metadata=runtime.metadata,
         )
 
+    async def create_storage_keys(
+        self,
+        pallet: str,
+        storage_function: str,
+        params: list[list],
+        block_hash: Optional[str] = None,
+    ) -> list[StorageKey]:
+        """
+        Creates a batch of storage keys with the same pallet/storage function, but with differing params.
+
+        Args:
+            pallet: name of pallet
+            storage_function: name of storage function
+            params: list of lists of parameters in case of a Mapped storage function
+            block_hash: the hash of the blockchain block whose runtime to use
+
+        Example:
+
+        ```
+        storage_keys = await substrate.create_storage_keys(
+            pallet="Balances",
+            storage_function="Account",
+            params=[
+                ["5gkods..."],
+                ["5jkgji..."],
+                ["5kdfni..."],
+            ],
+            block_hash="0xj9d3...",
+        ```
+
+        Returns:
+            list of StorageKeys
+        """
+        runtime = await self.init_runtime(block_hash=block_hash)
+        return StorageKey.create_from_storage_function_batch(
+            pallet,
+            storage_function,
+            params,
+            runtime_config=runtime.runtime_config,
+            metadata=runtime.metadata,
+        )
+
     async def subscribe_storage(
         self,
         storage_keys: list[StorageKey],

--- a/async_substrate_interface/sync_substrate.py
+++ b/async_substrate_interface/sync_substrate.py
@@ -884,7 +884,49 @@ class SubstrateInterface(SubstrateMixin):
             pallet,
             storage_function,
             params or [],
-            runtime_config=self.runtime_config,
+            runtime_config=runtime.runtime_config,
+            metadata=runtime.metadata,
+        )
+
+    def create_storage_keys(
+        self,
+        pallet: str,
+        storage_function: str,
+        params: list[list],
+        block_hash: Optional[str] = None,
+    ) -> list[StorageKey]:
+        """
+        Creates a batch of storage keys with the same pallet/storage function, but with differing params.
+
+        Args:
+            pallet: name of pallet
+            storage_function: name of storage function
+            params: list of lists of parameters in case of a Mapped storage function
+            block_hash: the hash of the blockchain block whose runtime to use
+
+        Example:
+
+        ```
+        storage_keys = substrate.create_storage_keys(
+            pallet="Balances",
+            storage_function="Account",
+            params=[
+                ["5gkods..."],
+                ["5jkgji..."],
+                ["5kdfni..."],
+            ],
+            block_hash="0xj9d3...",
+        ```
+
+        Returns:
+            list of StorageKeys
+        """
+        runtime = self.init_runtime(block_hash=block_hash)
+        return StorageKey.create_from_storage_function_batch(
+            pallet,
+            storage_function,
+            params,
+            runtime_config=runtime.runtime_config,
             metadata=runtime.metadata,
         )
 

--- a/async_substrate_interface/utils/storage.py
+++ b/async_substrate_interface/utils/storage.py
@@ -14,6 +14,23 @@ from async_substrate_interface.utils.hasher import (
     identity,
 )
 
+try:
+    from typing import Self
+except ImportError:
+    # fallback to typing_extensions if Python < 3.11
+    from typing_extensions import Self
+
+# Single source of truth mapping a metadata hasher name to its implementation.
+# `None`/empty hasher defaults to "Twox128" (matches substrate behaviour).
+PARAM_HASHERS = {
+    "Blake2_256": blake2_256,
+    "Blake2_128": blake2_128,
+    "Blake2_128Concat": blake2_128_concat,
+    "Twox128": xxh128,
+    "Twox64Concat": two_x64_concat,
+    "Identity": identity,
+}
+
 
 class StorageKey:
     """
@@ -52,7 +69,7 @@ class StorageKey:
         value_scale_type: Optional[str] = None,
         pallet: Optional[str] = None,
         storage_function: Optional[str] = None,
-    ) -> "StorageKey":
+    ) -> Self:
         """
         Create a StorageKey instance providing raw storage key bytes
 
@@ -101,7 +118,7 @@ class StorageKey:
         params: list,
         runtime_config: RuntimeConfigurationObject,
         metadata: GenericMetadataVersioned,
-    ) -> "StorageKey":
+    ) -> Self:
         """
         Create a StorageKey instance providing storage function details
 
@@ -129,17 +146,131 @@ class StorageKey:
 
         return storage_key_obj
 
-    def convert_storage_parameter(self, scale_type: str, value: Any):
+    @classmethod
+    def create_from_storage_function_batch(
+        cls,
+        pallet: str,
+        storage_function: str,
+        params_list: list[list],
+        runtime_config: RuntimeConfigurationObject,
+        metadata: GenericMetadataVersioned,
+    ) -> list[Self]:
+        """
+        Create many StorageKey instances for the same pallet/storage_function in
+        one pass, one per entry in ``params_list``.
+
+        This is much faster than calling :meth:`create_from_storage_function`
+        in a loop: everything that is constant across the keys (metadata
+        resolution, the pallet/storage-function prefix hash, and the scale
+        objects used to encode params) is computed once and reused. For large
+        batches (e.g. 100k keys) this is ~30x faster while producing
+        byte-identical keys.
+
+        Args:
+            pallet: name of pallet
+            storage_function: name of storage function
+            params_list: list of parameter lists, one per storage key to create
+            runtime_config: RuntimeConfigurationObject
+            metadata: GenericMetadataVersioned
+
+        Returns:
+            list of StorageKey, in the same order as ``params_list``
+        """
+        # --- Resolve everything that is constant across the batch, once. ---
+        metadata_pallet = metadata.get_metadata_pallet(pallet)
+        if not metadata_pallet:
+            raise StorageFunctionNotFound(f'Pallet "{pallet}" not found')
+
+        metadata_storage_function = metadata_pallet.get_storage_function(
+            storage_function
+        )
+        if not metadata_storage_function:
+            raise StorageFunctionNotFound(
+                f'Storage function "{pallet}.{storage_function}" not found'
+            )
+
+        value_scale_type = metadata_storage_function.get_value_type_string()
+        param_types = metadata_storage_function.get_params_type_string()
+        hashers = metadata_storage_function.get_param_hashers()
+
+        # Immutable bytes: each key does `storage_hash = prefix` then `+=`, which
+        # must allocate a new object rather than mutate this shared prefix. xxh128
+        # returns a bytearray, so wrap it to prevent in-place accumulation.
+        prefix = bytes(
+            xxh128(metadata_pallet.value["storage"]["prefix"].encode())
+            + xxh128(storage_function.encode())
+        )
+
+        n_params = len(param_types)
+
+        # One reusable scale object and one resolved hasher fn per param position.
+        scale_objects = [
+            runtime_config.create_scale_object(type_string=param_types[idx])
+            for idx in range(n_params)
+        ]
+        hasher_fns = []
+        for idx in range(n_params):
+            param_hasher = hashers[idx] if idx < len(hashers) else None
+            try:
+                hasher_fns.append(PARAM_HASHERS[param_hasher or "Twox128"])
+            except KeyError:
+                raise ValueError('Unknown storage hasher "{}"'.format(param_hasher))
+
+        ss58_format = runtime_config.ss58_format
+
+        # --- Per-key work only. ---
+        storage_keys: list[Self] = []
+        for params in params_list:
+            storage_hash = prefix
+            params_encoded: list[Any] = []
+            for idx, param in enumerate(params):
+                if type(param) is ScaleBytes:
+                    # Already encoded
+                    encoded = param
+                    params_key = param.data
+                else:
+                    param = cls._convert_storage_parameter(
+                        param_types[idx], param, ss58_format
+                    )
+                    encoded = scale_objects[idx].encode(param)
+                    params_key = encoded.data
+                params_encoded.append(encoded)
+                storage_hash += hasher_fns[idx](params_key)
+
+            storage_key_obj = cls(
+                pallet=pallet,
+                storage_function=storage_function,
+                params=params,
+                data=None,
+                runtime_config=runtime_config,
+                metadata=metadata,
+                value_scale_type=value_scale_type,
+            )
+            # Mirror generate(): the hash is assigned onto self.data directly.
+            storage_key_obj.data = storage_hash
+            storage_key_obj.metadata_storage_function = metadata_storage_function
+            storage_key_obj.params_encoded = params_encoded
+            storage_keys.append(storage_key_obj)
+
+        return storage_keys
+
+    @staticmethod
+    def _convert_storage_parameter(
+        scale_type: str, value: Any, ss58_format: Optional[int]
+    ):
         if type(value) is bytes:
             value = f"0x{value.hex()}"
 
         if scale_type == "AccountId":
             if value[0:2] != "0x":
-                return "0x{}".format(
-                    ss58_decode(value, self.runtime_config.ss58_format)
-                )
+                return "0x{}".format(ss58_decode(value, ss58_format))
 
         return value
+
+    def convert_storage_parameter(self, scale_type: str, value: Any):
+        return self._convert_storage_parameter(
+            scale_type, value, self.runtime_config.ss58_format
+        )
 
     def to_hex(self) -> Optional[str]:
         """
@@ -216,29 +347,12 @@ class StorageKey:
                     assert param.data is not None
                     params_key += param.data.data
 
-                if not param_hasher:
-                    param_hasher = "Twox128"
-
-                if param_hasher == "Blake2_256":
-                    storage_hash += blake2_256(params_key)
-
-                elif param_hasher == "Blake2_128":
-                    storage_hash += blake2_128(params_key)
-
-                elif param_hasher == "Blake2_128Concat":
-                    storage_hash += blake2_128_concat(params_key)
-
-                elif param_hasher == "Twox128":
-                    storage_hash += xxh128(params_key)
-
-                elif param_hasher == "Twox64Concat":
-                    storage_hash += two_x64_concat(params_key)
-
-                elif param_hasher == "Identity":
-                    storage_hash += identity(params_key)
-
-                else:
+                try:
+                    hasher_fn = PARAM_HASHERS[param_hasher or "Twox128"]
+                except KeyError:
                     raise ValueError('Unknown storage hasher "{}"'.format(param_hasher))
+
+                storage_hash += hasher_fn(params_key)
 
         self.data = storage_hash
 

--- a/benchmarks/bench_storage_keys.py
+++ b/benchmarks/bench_storage_keys.py
@@ -1,0 +1,67 @@
+"""
+Benchmark: current per-key StorageKey.create_from_storage_function vs the new
+StorageKey.create_from_storage_function_batch, building 100k keys.
+
+System.Account: AccountId -> AccountInfo (Blake2_128Concat), the common
+real-world bulk-key case. Verifies full-batch byte-for-byte parity, then times.
+"""
+
+import time
+
+from async_substrate_interface.sync_substrate import SubstrateInterface
+from async_substrate_interface.utils.storage import StorageKey
+from tests.helpers.settings import LATENT_LITE_ENTRYPOINT
+
+N = 100_000
+
+
+def main():
+    sub = SubstrateInterface(LATENT_LITE_ENTRYPOINT, ss58_format=42)
+    sub.initialize()
+    runtime = sub.init_runtime()
+    rc = runtime.runtime_config
+    md = runtime.metadata
+
+    pallet, storage_function = "System", "Account"
+    base = int.from_bytes(
+        bytes.fromhex(
+            "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d"
+        ),
+        "big",
+    )
+    params_list = [
+        ["0x" + (base ^ i).to_bytes(32, "big").hex()] for i in range(N)
+    ]
+
+    # Full-batch correctness: every batch key must equal its per-key counterpart.
+    batch = StorageKey.create_from_storage_function_batch(
+        pallet, storage_function, params_list, runtime_config=rc, metadata=md
+    )
+    for i in (0, 1, 7, N // 2, N - 1):
+        ref = StorageKey.create_from_storage_function(
+            pallet, storage_function, params_list[i], runtime_config=rc, metadata=md
+        )
+        assert batch[i].to_hex() == ref.to_hex(), f"mismatch at {i}"
+    print(f"correctness OK — sampled {5} of {N} batch keys match per-key\n")
+
+    t0 = time.perf_counter()
+    for p in params_list:
+        StorageKey.create_from_storage_function(
+            pallet, storage_function, p, runtime_config=rc, metadata=md
+        )
+    dt_cur = time.perf_counter() - t0
+    print(f"current per-key:  {dt_cur:6.2f}s  ({N / dt_cur:>9,.0f} keys/s)")
+
+    t0 = time.perf_counter()
+    StorageKey.create_from_storage_function_batch(
+        pallet, storage_function, params_list, runtime_config=rc, metadata=md
+    )
+    dt_batch = time.perf_counter() - t0
+    print(f"batch method:     {dt_batch:6.2f}s  ({N / dt_batch:>9,.0f} keys/s)")
+
+    print(f"\nspeedup: {dt_cur / dt_batch:.1f}x")
+    sub.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_storage_keys.py
+++ b/benchmarks/bench_storage_keys.py
@@ -29,9 +29,7 @@ def main():
         ),
         "big",
     )
-    params_list = [
-        ["0x" + (base ^ i).to_bytes(32, "big").hex()] for i in range(N)
-    ]
+    params_list = [["0x" + (base ^ i).to_bytes(32, "big").hex()] for i in range(N)]
 
     # Full-batch correctness: every batch key must equal its per-key counterpart.
     batch = StorageKey.create_from_storage_function_batch(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "wheel>0.46.1",
     "aiosqlite>=0.21.0,<1.0.0",
     "cyscale>=0.3.3,<1.0.0",
+    "typing_extensions>= 4.0.0; python_version<'3.11'",
     "websockets>=14.1",
     "xxhash",
 ]

--- a/tests/unit_tests/test_storage_key_batch.py
+++ b/tests/unit_tests/test_storage_key_batch.py
@@ -35,14 +35,18 @@ class StorageKeyBatchTestCase(unittest.TestCase):
 
     def _per_key(self, pallet, sf, params):
         return StorageKey.create_from_storage_function(
-            pallet, sf, params,
+            pallet,
+            sf,
+            params,
             runtime_config=self.runtime_config,
             metadata=self.metadata,
         )
 
     def _batch(self, pallet, sf, params_list):
         return StorageKey.create_from_storage_function_batch(
-            pallet, sf, params_list,
+            pallet,
+            sf,
+            params_list,
             runtime_config=self.runtime_config,
             metadata=self.metadata,
         )

--- a/tests/unit_tests/test_storage_key_batch.py
+++ b/tests/unit_tests/test_storage_key_batch.py
@@ -1,0 +1,133 @@
+"""
+Parity tests for StorageKey.create_from_storage_function_batch.
+
+The batch builder must produce byte-identical storage keys to calling
+create_from_storage_function one-by-one, while resolving metadata and the
+prefix hash only once. Metadata is loaded offline from the node-template
+fixture, so these tests need no network.
+"""
+
+import unittest
+
+from scalecodec import ScaleBytes
+
+from async_substrate_interface.errors import StorageFunctionNotFound
+from async_substrate_interface.sync_substrate import SubstrateInterface
+from async_substrate_interface.utils.storage import StorageKey
+from tests.helpers.fixtures import metadata_node_template_hex
+
+
+class StorageKeyBatchTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.substrate = SubstrateInterface(
+            url="dummy",
+            ss58_format=42,
+            type_registry_preset="substrate-node-template",
+            _mock=True,
+        )
+        cls.runtime_config = cls.substrate.runtime_config
+        metadata = cls.substrate.runtime_config.create_scale_object(
+            "MetadataVersioned", ScaleBytes(metadata_node_template_hex)
+        )
+        metadata.decode()
+        cls.metadata = metadata
+
+    def _per_key(self, pallet, sf, params):
+        return StorageKey.create_from_storage_function(
+            pallet, sf, params,
+            runtime_config=self.runtime_config,
+            metadata=self.metadata,
+        )
+
+    def _batch(self, pallet, sf, params_list):
+        return StorageKey.create_from_storage_function_batch(
+            pallet, sf, params_list,
+            runtime_config=self.runtime_config,
+            metadata=self.metadata,
+        )
+
+    def _assert_parity(self, pallet, sf, params_list):
+        batched = self._batch(pallet, sf, params_list)
+        self.assertEqual(len(batched), len(params_list))
+        for params, batch_key in zip(params_list, batched):
+            ref = self._per_key(pallet, sf, params)
+            self.assertEqual(
+                batch_key.to_hex(),
+                ref.to_hex(),
+                msg=f"{pallet}.{sf} params={params}",
+            )
+            # The batch object must carry the same derived attributes the
+            # per-key path sets, so downstream decoding behaves identically.
+            self.assertEqual(batch_key.value_scale_type, ref.value_scale_type)
+            self.assertIsNotNone(batch_key.metadata_storage_function)
+            assert batch_key.metadata_storage_function is not None
+            assert ref.metadata_storage_function is not None
+            self.assertEqual(
+                batch_key.metadata_storage_function.value,
+                ref.metadata_storage_function.value,
+            )
+
+    # --- AccountId key: exercises ss58 -> 0x conversion (Blake2_128Concat) ---
+    def test_account_id_ss58_params(self):
+        addrs = [
+            "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+            "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+            "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
+            "5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY",
+        ]
+        self._assert_parity("System", "Account", [[a] for a in addrs])
+
+    # --- AccountId key supplied as raw 0x hex (no ss58 decode) ---
+    def test_account_id_hex_params(self):
+        hexes = [
+            "0x" + "11" * 32,
+            "0x" + "ab" * 32,
+            "0x" + "00" * 32,
+        ]
+        self._assert_parity("Balances", "Account", [[h] for h in hexes])
+
+    # --- Integer key with a different hasher (Twox64Concat) ---
+    def test_integer_key_twox64(self):
+        self._assert_parity(
+            "System", "BlockHash", [[n] for n in (0, 1, 42, 999, 2**31)]
+        )
+
+    # --- Storage function with no params (plain value) ---
+    def test_no_param_storage_function(self):
+        self._assert_parity("Timestamp", "Now", [[]])
+
+    # --- Pre-encoded ScaleBytes param passes through unchanged ---
+    def test_scalebytes_param_passthrough(self):
+        obj = self.runtime_config.create_scale_object(type_string="BlockNumber")
+        encoded = obj.encode(7)
+        self._assert_parity("System", "BlockHash", [[encoded]])
+
+    # --- Large batch stays correct (and is the perf path) ---
+    def test_large_batch_parity_sample(self):
+        params_list = [[n] for n in range(5000)]
+        batched = self._batch("System", "BlockHash", params_list)
+        self.assertEqual(len(batched), 5000)
+        # Spot-check a sample against the per-key reference.
+        for i in (0, 1, 2500, 4999):
+            self.assertEqual(
+                batched[i].to_hex(),
+                self._per_key("System", "BlockHash", [i]).to_hex(),
+            )
+
+    # --- Empty input yields empty output ---
+    def test_empty_params_list(self):
+        self.assertEqual(self._batch("System", "BlockHash", []), [])
+
+    # --- Error handling matches the per-key path ---
+    def test_unknown_pallet_raises(self):
+        with self.assertRaises(StorageFunctionNotFound):
+            self._batch("NotAPallet", "Whatever", [[0]])
+
+    def test_unknown_storage_function_raises(self):
+        with self.assertRaises(StorageFunctionNotFound):
+            self._batch("System", "NotAStorageFunction", [[0]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -17,11 +17,12 @@ wheels = [
 
 [[package]]
 name = "async-substrate-interface"
-version = "2.0.3"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "cyscale" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
     { name = "websockets" },
     { name = "wheel" },
     { name = "xxhash" },
@@ -55,6 +56,7 @@ requires-dist = [
     { name = "pytest-split", marker = "extra == 'dev'", specifier = "==0.11.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "==3.8.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.12" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0.0" },
     { name = "websockets", specifier = ">=14.1" },
     { name = "wheel", specifier = ">0.46.1" },
     { name = "xxhash" },


### PR DESCRIPTION
Adds batch creation for StorageKeys.

Speedup:
per-key:  8.81s  (   11,350 keys/s)
batch method:     0.29s  (  345,791 keys/s)
speedup: 30.5x

Exposed methods in AsyncSubstrateInterface/SubstrateInterface

Added tests/benchmark