### PR TITLE
fix(pyproject): drop unused wheel dep, update setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ license = { file = "LICENSE" }
 keywords = ["substrate", "development", "bittensor"]
 
 dependencies = [
-    "wheel>0.46.1",
     "aiosqlite>=0.21.0,<1.0.0",
     "cyscale>=0.3.3,<1.0.0",
     "websockets>=14.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ asyncio_default_fixture_loop_scope = "module"
 ignore_missing_imports = true
 
 [build-system]
-requires = ["setuptools>=70.0", "wheel"]
+requires = ["setuptools>=78.1.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes https://github.com/latent-to/bittensor/issues/3376
TL;DR: `wheel` doesn't need to be in `dependencies`. This PR drops it, and no functionality changes should be caused by this change.

Also updates the minimum required setuptools version to match that used in the main bittensor repo, where it was updated due to CVEs. See: https://github.com/latent-to/bittensor/pull/3339

